### PR TITLE
refactor: 에러타입 네이밍 수정

### DIFF
--- a/GraceLog/Source/Data/Network/DTO/APIError.swift
+++ b/GraceLog/Source/Data/Network/DTO/APIError.swift
@@ -9,27 +9,27 @@ import Foundation
 import Alamofire
 
 enum APIError: Error {
-    case serverError(code: Int, message: String)
+    case httpError(code: Int, message: String)
     case networkError(Error)
 }
 
 extension APIError: LocalizedError {
     var errorDescription: String? {
         switch self {
-        case .serverError(_, let message):
+        case .httpError(_, let message):
             return message
         case .networkError(let error):
             if let afError = error as? AFError {
-                return mapAFErrorToKorean(afError)
+                return getAFErrorMessageToKorean(afError)
             } else if let urlError = error as? URLError {
-                return mapURLErrorToKorean(urlError)
+                return getURLErrorMessageToKorean(urlError)
             } else {
                 return "네트워크 오류가 발생했습니다"
             }
         }
     }
     
-    private func mapAFErrorToKorean(_ afError: AFError) -> String {
+    private func getAFErrorMessageToKorean(_ afError: AFError) -> String {
         switch afError {
         case .responseValidationFailed:
             return "서버 응답이 올바르지 않습니다"
@@ -40,7 +40,7 @@ extension APIError: LocalizedError {
         }
     }
     
-    private func mapURLErrorToKorean(_ urlError: URLError) -> String {
+    private func getURLErrorMessageToKorean(_ urlError: URLError) -> String {
         switch urlError.code {
         case .notConnectedToInternet:
             return "인터넷 연결을 확인해주세요"

--- a/GraceLog/Source/Data/Network/Service/Auth/AuthService.swift
+++ b/GraceLog/Source/Data/Network/Service/Auth/AuthService.swift
@@ -19,7 +19,7 @@ struct AuthService {
                         if response.code == 200, let data = response.data {
                             single(.success(data))
                         }  else {
-                            let error = APIError.serverError(
+                            let error = APIError.httpError(
                                 code: response.code,
                                 message: response.message
                             )

--- a/GraceLog/Source/Data/Network/Service/User/UserService.swift
+++ b/GraceLog/Source/Data/Network/Service/User/UserService.swift
@@ -19,7 +19,7 @@ struct UserService {
                         if response.code == 200, let data = response.data {
                             single(.success(data))
                         } else {
-                            let error = APIError.serverError(
+                            let error = APIError.httpError(
                                 code: response.code,
                                 message: response.message
                             )
@@ -43,7 +43,7 @@ struct UserService {
                         if response.code == 200, let data = response.data {
                             single(.success(data))
                         } else {
-                            let error = APIError.serverError(
+                            let error = APIError.httpError(
                                 code: response.code,
                                 message: response.message
                             )


### PR DESCRIPTION
### 에러타입 네이밍 수정 
- serverError -> httpError (400, 500번때 코드를 통칭할 수 있는 네이밍)

```
API 통신 시 에러 예시

{
    "code": 401,
    "message": "토큰이 유효하지 않습니다."
} 

{
   "code":500,
    "message": "서버에서 에러가 발생했습니다."
}

```