### PR TITLE
Feat/chatapi

### DIFF
--- a/GraceLog.xcodeproj/project.pbxproj
+++ b/GraceLog.xcodeproj/project.pbxproj
@@ -62,6 +62,10 @@
 		709CBB6D2E2B8CA100F68457 /* CommentToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709CBB6C2E2B8CA100F68457 /* CommentToggleButton.swift */; };
 		709FEE902F2B64FF00FDD22B /* CommentAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709FEE8F2F2B64FF00FDD22B /* CommentAPI.swift */; };
 		709FEE922F2B860100FDD22B /* CreateCommentRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709FEE912F2B860100FDD22B /* CreateCommentRequestDTO.swift */; };
+		709FEE942F2B8A9400FDD22B /* DefaultCommentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709FEE932F2B8A9400FDD22B /* DefaultCommentRepository.swift */; };
+		709FEE962F2B8AA500FDD22B /* CommentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709FEE952F2B8AA500FDD22B /* CommentRepository.swift */; };
+		709FEE972F2B8AA600FDD22B /* CommentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709FEE952F2B8AA500FDD22B /* CommentRepository.swift */; };
+		709FEE982F2B8AA600FDD22B /* CommentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709FEE952F2B8AA500FDD22B /* CommentRepository.swift */; };
 		709FEE9A2F2B8EB500FDD22B /* FetchCommentListResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709FEE992F2B8EB500FDD22B /* FetchCommentListResponseDTO.swift */; };
 		70A97C462E18F5B900F08DF6 /* DiaryKeyword.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A97C452E18F5B900F08DF6 /* DiaryKeyword.swift */; };
 		70A97C482E18F61000F08DF6 /* Community.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A97C472E18F61000F08DF6 /* Community.swift */; };
@@ -343,6 +347,8 @@
 		709CBB6C2E2B8CA100F68457 /* CommentToggleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentToggleButton.swift; sourceTree = "<group>"; };
 		709FEE8F2F2B64FF00FDD22B /* CommentAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentAPI.swift; sourceTree = "<group>"; };
 		709FEE912F2B860100FDD22B /* CreateCommentRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCommentRequestDTO.swift; sourceTree = "<group>"; };
+		709FEE932F2B8A9400FDD22B /* DefaultCommentRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCommentRepository.swift; sourceTree = "<group>"; };
+		709FEE952F2B8AA500FDD22B /* CommentRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentRepository.swift; sourceTree = "<group>"; };
 		709FEE992F2B8EB500FDD22B /* FetchCommentListResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchCommentListResponseDTO.swift; sourceTree = "<group>"; };
 		70A97C452E18F5B900F08DF6 /* DiaryKeyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryKeyword.swift; sourceTree = "<group>"; };
 		70A97C472E18F61000F08DF6 /* Community.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Community.swift; sourceTree = "<group>"; };
@@ -1183,6 +1189,7 @@
 				DEA80D912F05048C00216B1D /* VideoRepository.swift */,
 				DEA80D992F050B1F00216B1D /* DailyVerseRepository.swift */,
 				DE645B932F206A1D00C98B5A /* AnnouncementRepository.swift */,
+				709FEE952F2B8AA500FDD22B /* CommentRepository.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1208,6 +1215,7 @@
 				DEA80D972F0507A500216B1D /* DefaultLikeRepository.swift */,
 				DEA80D9D2F050B3F00216B1D /* DefaultDailyVerseRepository.swift */,
 				DE645B972F206A9400C98B5A /* DefaultAnnouncementRepository.swift */,
+				709FEE932F2B8A9400FDD22B /* DefaultCommentRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -1945,6 +1953,7 @@
 				DE24DB6E2D26D36100581621 /* MockFireStoreRepository.swift in Sources */,
 				DEEFEACC2D2A5E8200699692 /* GraceLogUser.swift in Sources */,
 				DEA80D842F026BAC00216B1D /* CommunityRepository.swift in Sources */,
+				709FEE972F2B8AA600FDD22B /* CommentRepository.swift in Sources */,
 				DEA80D8E2F05048000216B1D /* LikeRepository.swift in Sources */,
 				DE645B962F206A1D00C98B5A /* AnnouncementRepository.swift in Sources */,
 				DEEFEAC12D26D4B800699692 /* SignInUseCase.swift in Sources */,
@@ -2098,6 +2107,7 @@
 				DE27005C2D212609005C9DCF /* DefaultSignInUseCase.swift in Sources */,
 				DE2387362E0A66DA00893D8C /* HomeMyDiaryView.swift in Sources */,
 				70F0061A2E0EC12C00228C70 /* DiaryTimelineCollectionViewCell.swift in Sources */,
+				709FEE962F2B8AA500FDD22B /* CommentRepository.swift in Sources */,
 				DE93B6F52ECDF6C000BCFB5D /* CommunityDiaryListRequestDTO.swift in Sources */,
 				DE042C3F2E93FCE90089E20F /* DiaryDetailsCoordinator.swift in Sources */,
 				DE2387412E0BB83B00893D8C /* HomeMyRecommendVideoView.swift in Sources */,
@@ -2146,6 +2156,7 @@
 				DED558662DABAFBE00137B10 /* CommonSectionWithDescHeaderView.swift in Sources */,
 				DE645A472F1B696800C98B5A /* AnnouncementPresentationAssembly.swift in Sources */,
 				DE23872E2E07C2DC00893D8C /* HomeMyViewController.swift in Sources */,
+				709FEE942F2B8A9400FDD22B /* DefaultCommentRepository.swift in Sources */,
 				DE27005A2D2125FF005C9DCF /* SignInUseCase.swift in Sources */,
 				DE42374C2EBCCDB4006FAA7B /* DateRangeDiaryListRequestDTO.swift in Sources */,
 				704815822E018E30009ECDBD /* GLDividerView.swift in Sources */,
@@ -2190,6 +2201,7 @@
 				DE58FED22D04284E008CADCD /* GraceLogUITests.swift in Sources */,
 				DEA80D922F05048C00216B1D /* VideoRepository.swift in Sources */,
 				DEA80D8F2F05048000216B1D /* LikeRepository.swift in Sources */,
+				709FEE982F2B8AA600FDD22B /* CommentRepository.swift in Sources */,
 				DEEFEACD2D2A5E8400699692 /* GraceLogUser.swift in Sources */,
 				DED5588B2DBE226D00137B10 /* AuthRepository.swift in Sources */,
 				DEEFEAC02D26D4B800699692 /* SignInUseCase.swift in Sources */,

--- a/GraceLog.xcodeproj/project.pbxproj
+++ b/GraceLog.xcodeproj/project.pbxproj
@@ -60,6 +60,9 @@
 		709CBB692E2ACB5100F68457 /* CommentSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709CBB682E2ACB5100F68457 /* CommentSection.swift */; };
 		709CBB6B2E2AD2C400F68457 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709CBB6A2E2AD2C400F68457 /* Comment.swift */; };
 		709CBB6D2E2B8CA100F68457 /* CommentToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709CBB6C2E2B8CA100F68457 /* CommentToggleButton.swift */; };
+		709FEE902F2B64FF00FDD22B /* CommentAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709FEE8F2F2B64FF00FDD22B /* CommentAPI.swift */; };
+		709FEE922F2B860100FDD22B /* CreateCommentRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709FEE912F2B860100FDD22B /* CreateCommentRequestDTO.swift */; };
+		709FEE9A2F2B8EB500FDD22B /* FetchCommentListResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709FEE992F2B8EB500FDD22B /* FetchCommentListResponseDTO.swift */; };
 		70A97C462E18F5B900F08DF6 /* DiaryKeyword.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A97C452E18F5B900F08DF6 /* DiaryKeyword.swift */; };
 		70A97C482E18F61000F08DF6 /* Community.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A97C472E18F61000F08DF6 /* Community.swift */; };
 		70A97C4A2E191F0900F08DF6 /* DiaryDeletableUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A97C492E191F0900F08DF6 /* DiaryDeletableUseCase.swift */; };
@@ -338,6 +341,9 @@
 		709CBB682E2ACB5100F68457 /* CommentSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentSection.swift; sourceTree = "<group>"; };
 		709CBB6A2E2AD2C400F68457 /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		709CBB6C2E2B8CA100F68457 /* CommentToggleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentToggleButton.swift; sourceTree = "<group>"; };
+		709FEE8F2F2B64FF00FDD22B /* CommentAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentAPI.swift; sourceTree = "<group>"; };
+		709FEE912F2B860100FDD22B /* CreateCommentRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCommentRequestDTO.swift; sourceTree = "<group>"; };
+		709FEE992F2B8EB500FDD22B /* FetchCommentListResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchCommentListResponseDTO.swift; sourceTree = "<group>"; };
 		70A97C452E18F5B900F08DF6 /* DiaryKeyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryKeyword.swift; sourceTree = "<group>"; };
 		70A97C472E18F61000F08DF6 /* Community.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Community.swift; sourceTree = "<group>"; };
 		70A97C492E191F0900F08DF6 /* DiaryDeletableUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDeletableUseCase.swift; sourceTree = "<group>"; };
@@ -1574,6 +1580,7 @@
 				DE93B6FA2ED060DD00BCFB5D /* DailyVerseAPI.swift */,
 				DECCC6252EE5811D00E893DB /* YoutubeAPI.swift */,
 				DE645B8D2F2066DF00C98B5A /* AnnouncementAPI.swift */,
+				709FEE8F2F2B64FF00FDD22B /* CommentAPI.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1603,6 +1610,7 @@
 				DE4237572EBF07AF006FAA7B /* LikeDiaryRequestDTO.swift */,
 				DE4237592EC20AB8006FAA7B /* LikeCountRequestDTO.swift */,
 				DE93B6F42ECDF6C000BCFB5D /* CommunityDiaryListRequestDTO.swift */,
+				709FEE912F2B860100FDD22B /* CreateCommentRequestDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -1619,6 +1627,7 @@
 				DE93B6FC2ED061EB00BCFB5D /* DailyVerseResponseDTO.swift */,
 				DECCC6272EE582E000E893DB /* VideoResponseDTO.swift */,
 				DE645B912F2069DE00C98B5A /* AnnouncementResponseDTO.swift */,
+				709FEE992F2B8EB500FDD22B /* FetchCommentListResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1975,6 +1984,7 @@
 				709CBB652E2AC3A300F68457 /* CommentInfoView.swift in Sources */,
 				704815842E018F5A009ECDBD /* DiaryEditView.swift in Sources */,
 				DE6459B32F10CBC700C98B5A /* NotificationCenterManager.swift in Sources */,
+				709FEE902F2B64FF00FDD22B /* CommentAPI.swift in Sources */,
 				DECF2AA52E28B4B9000CAF42 /* GLInterceptor.swift in Sources */,
 				DE47E9792E48790300C379C3 /* MyInfoProfileView.swift in Sources */,
 				DE597A6E2E26141100B2CB5B /* AuthPresentationAssembly.swift in Sources */,
@@ -2062,6 +2072,7 @@
 				02DC298B2DDC29C000662D8A /* MyInfoButtonTableViewCell.swift in Sources */,
 				70A97C5A2E215F5700F08DF6 /* DomainAssembly.swift in Sources */,
 				02DC298C2DDC29C000662D8A /* MyInfoDataSource.swift in Sources */,
+				709FEE9A2F2B8EB500FDD22B /* FetchCommentListResponseDTO.swift in Sources */,
 				DECF2A9F2E26A0AB000CAF42 /* HeaderType.swift in Sources */,
 				DE42374A2EBCCBCE006FAA7B /* MyDiaryListRequestDTO.swift in Sources */,
 				DE23872A2E003BDE00893D8C /* GLNavigationBar.swift in Sources */,
@@ -2107,6 +2118,7 @@
 				DE9A1FEC2D7C04C50044F655 /* Bundle.swift in Sources */,
 				DECCC6282EE582E000E893DB /* VideoResponseDTO.swift in Sources */,
 				0295ADFB2DED3AEF00B97DB1 /* GraceLogBaseViewController.swift in Sources */,
+				709FEE922F2B860100FDD22B /* CreateCommentRequestDTO.swift in Sources */,
 				DEA80D902F05048000216B1D /* LikeRepository.swift in Sources */,
 				DEF8D6762E1A925100685517 /* DefaultHomeCommunityUseCase.swift in Sources */,
 				DED5589D2DC4AD3700137B10 /* Crypto.swift in Sources */,

--- a/GraceLog/Source/Data/Network/API/CommentAPI.swift
+++ b/GraceLog/Source/Data/Network/API/CommentAPI.swift
@@ -1,0 +1,52 @@
+//
+//  CommentAPI.swift
+//  GraceLog
+//
+//  Created by 이건준 on 1/29/26.
+//
+
+import Alamofire
+
+enum CommentAPI {
+    case fetchCommentList(postId: Int)
+    case createComment(postId: Int, request: CreateCommentRequestDTO)
+    case fetchReplyList(parentId: Int)
+}
+
+extension CommentAPI: TargetType {
+    var baseURL: String {
+        return "http://\(Const.baseURL)/comment"
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .fetchCommentList, .fetchReplyList: return .get
+        case .createComment: return .post
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case let .fetchCommentList(postId):
+            return "/post/\(postId)"
+        case let .createComment(postId, _):
+            return "/post/\(postId)"
+        case let .fetchReplyList(parentId):
+            return "/parent/\(parentId)"
+        }
+    }
+    
+    var headers: HeaderType {
+        return .requireAccessToken
+    }
+    
+    var parameters: RequestParams {
+        switch self {
+        case .fetchCommentList, .fetchReplyList:
+            return .none
+        case let .createComment(_, request):
+            return .body(request)
+        }
+    }
+}
+

--- a/GraceLog/Source/Data/Network/DTO/Request/CreateCommentRequestDTO.swift
+++ b/GraceLog/Source/Data/Network/DTO/Request/CreateCommentRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  CreateCommentRequestDTO.swift
+//  GraceLog
+//
+//  Created by 이건준 on 1/29/26.
+//
+
+import Foundation
+
+struct CreateCommentRequestDTO: Encodable {
+    let content: String
+    let parentId: Int
+}

--- a/GraceLog/Source/Data/Network/DTO/Response/DiaryResponseDTO.swift
+++ b/GraceLog/Source/Data/Network/DTO/Response/DiaryResponseDTO.swift
@@ -12,6 +12,19 @@ struct DiaryPagingResponseDTO: Decodable {
     let size: Int
     let first: Bool
     let last: Bool
+    let numberOfElements: Int
+    let sort: [String]
+    let empty: Bool
+    let pageable: Pageable
+}
+
+struct Pageable: Decodable {
+    let unpaged: Bool
+    let pageNumber: Int
+    let offset: Int
+    let pageSize: Int
+    let sort: [String]
+    let paged: Bool
 }
 
 struct DiaryResponseDTO: Decodable {
@@ -34,6 +47,6 @@ struct DiaryResponseDTO: Decodable {
 
 struct DiaryImagesInfo: Decodable {
     let id: Int
-    let url: URL
+    let url: String
     let fileName: String
 }

--- a/GraceLog/Source/Data/Network/DTO/Response/FetchCommentListResponseDTO.swift
+++ b/GraceLog/Source/Data/Network/DTO/Response/FetchCommentListResponseDTO.swift
@@ -1,0 +1,30 @@
+//
+//  FetchCommentListResponseDTO.swift
+//  GraceLog
+//
+//  Created by 이건준 on 1/29/26.
+//
+
+import Foundation
+
+struct FetchCommentListResponseDTO: Decodable {
+    let id: Int
+    let content: String
+    let writer: Writer
+    let parentId: Int
+    let replies: [String]
+    let replyCount: Int
+    let createdAt: String
+    let updatedAt: String
+}
+
+struct Writer: Decodable {
+    let memberId: Int
+    let email: String
+    let name: String
+    let nickname: String
+    let profileImage: String
+    let message: String
+    let createdAt: String
+    let updatedAt: String
+}

--- a/GraceLog/Source/Data/Network/DTO/Response/UserResponseDTO.swift
+++ b/GraceLog/Source/Data/Network/DTO/Response/UserResponseDTO.swift
@@ -11,7 +11,9 @@ struct UserResponseDTO: Decodable {
     let memberId: Int
     let name: String
     let nickname: String
-    let profileImage: URL?
+    let profileImage: String
     let email: String
     let message: String
+    let updatedAt: String
+    let createdAt: String
 }

--- a/GraceLog/Source/Data/Repository/DefaultCommentRepository.swift
+++ b/GraceLog/Source/Data/Repository/DefaultCommentRepository.swift
@@ -1,0 +1,54 @@
+//
+//  DefaultCommentRepository.swift
+//  GraceLog
+//
+//  Created by 이건준 on 1/29/26.
+//
+
+import RxSwift
+
+final class DefaultCommentRepository: CommentRepository {
+    private let network: NetworkManager
+    
+    init(network: NetworkManager) {
+        self.network = network
+    }
+    
+    func fetchCommentList(postId: Int) -> RxSwift.Single<[Comment]> {
+        return network.request(CommentAPI.fetchCommentList(postId: postId))
+            .map { (responses: [FetchCommentListResponseDTO]) in
+                return responses.map { response in
+                    Comment(
+                        id: response.id,
+                        authorName: response.writer.name,
+                        createdAt: response.createdAt,
+                        profileImageURL: URL(string: response.writer.profileImage),
+                        comment: response.content,
+                        replyCount: response.replyCount,
+                        subComments: []
+                    )
+                }
+            }
+    }
+    
+    func fetchReplyList(parentId: Int) -> RxSwift.Single<[Comment]> {
+        network.request(CommentAPI.fetchReplyList(parentId: parentId))
+            .map { (responses: [FetchCommentListResponseDTO]) in
+                return responses.map { response in
+                    Comment(
+                        id: response.id,
+                        authorName: response.writer.name,
+                        createdAt: response.createdAt,
+                        profileImageURL: URL(string: response.writer.profileImage),
+                        comment: response.content,
+                        replyCount: response.replyCount,
+                        subComments: []
+                    )
+                }
+            }
+    }
+    
+    func createComment(request: CreateCommentRequestDTO, postId: Int) -> RxSwift.Single<GLEmptyResponse> {
+        network.request(CommentAPI.createComment(postId: postId, request: request))
+    }
+}

--- a/GraceLog/Source/Data/Repository/DefaultDiaryRepository.swift
+++ b/GraceLog/Source/Data/Repository/DefaultDiaryRepository.swift
@@ -28,11 +28,11 @@ final class DefaultDiaryRepository: DiaryRepository {
                         id: responseDTO.member.memberId,
                         name: responseDTO.member.name,
                         nickname: responseDTO.member.nickname,
-                        profileImageURL: responseDTO.member.profileImage,
+                        profileImageURL: URL(string: responseDTO.member.profileImage),
                         email: responseDTO.member.email,
                         message: responseDTO.member.message
                     ),
-                    imageURLs: responseDTO.postImages.map { $0.url },
+                    imageURLs: responseDTO.postImages.compactMap { URL(string: $0.url) },
                     likeCount: responseDTO.likeCount,
                     likeByMe: responseDTO.likedByMe,
                     isHideLike: responseDTO.isHideLike,
@@ -54,7 +54,7 @@ final class DefaultDiaryRepository: DiaryRepository {
                         editedDate: DateFormatterFactory.dateTimeWithISO.date(from: diaryResponseDTO.updatedAt),
                         title: diaryResponseDTO.title,
                         content: diaryResponseDTO.description,
-                        imageURL: diaryResponseDTO.postImages.first?.url
+                        imageURL: nil
                     )
                 }
             }
@@ -65,28 +65,28 @@ final class DefaultDiaryRepository: DiaryRepository {
         let request = DateRangeDiaryListRequestDTO(startDate: startDate, endDate: endDate, communityId: communityId, memberId: memberId)
         
         return network.request(DiaryAPI.fetchDateRangeDiaryList(request))
-            .map { (responseDTO: [DiaryResponseDTO]) in
-                return responseDTO.map { diaryResponseDTO in
+            .map { (responseDTO: DiaryPagingResponseDTO) in
+                return responseDTO.content.map { content in
                     return DiaryDetails(
-                        diaryId: diaryResponseDTO.postId,
-                        communityId: diaryResponseDTO.postCommunityId,
-                        title: diaryResponseDTO.title,
-                        description: diaryResponseDTO.description,
+                        diaryId: content.postId,
+                        communityId: content.postCommunityId,
+                        title: content.title,
+                        description: content.description,
                         user: GraceLogUser(
-                            id: diaryResponseDTO.member.memberId,
-                            name: diaryResponseDTO.member.name,
-                            nickname: diaryResponseDTO.member.nickname,
-                            profileImageURL: diaryResponseDTO.member.profileImage,
-                            email: diaryResponseDTO.member.email,
-                            message: diaryResponseDTO.member.message
+                            id: content.member.memberId,
+                            name: content.member.name,
+                            nickname: content.member.nickname,
+                            profileImageURL: URL(string: content.member.profileImage),
+                            email: content.member.email,
+                            message: content.member.message
                         ),
-                        imageURLs: diaryResponseDTO.postImages.map { $0.url },
-                        likeCount: diaryResponseDTO.likeCount,
-                        likeByMe: diaryResponseDTO.likedByMe,
-                        isHideLike: diaryResponseDTO.isHideLike,
-                        isHideComment: diaryResponseDTO.isHideComment,
-                        commentCount: diaryResponseDTO.commentCount,
-                        createdAt: DateFormatterFactory.dateTimeWithISO.date(from: diaryResponseDTO.createdAt)
+                        imageURLs: content.postImages.compactMap { URL(string: $0.url) },
+                        likeCount: content.likeCount,
+                        likeByMe: content.likedByMe,
+                        isHideLike: content.isHideLike,
+                        isHideComment: content.isHideComment,
+                        commentCount: content.commentCount,
+                        createdAt: DateFormatterFactory.dateTimeWithISO.date(from: content.createdAt)
                     )
                 }
             }
@@ -111,8 +111,8 @@ final class DefaultDiaryRepository: DiaryRepository {
                         likeCount: diaryResponseDTO.likeCount,
                         commentCount: diaryResponseDTO.commentCount,
                         username: diaryResponseDTO.member.name,
-                        profileImageURL: diaryResponseDTO.member.profileImage,
-                        diaryImageURL: diaryResponseDTO.postImages.first?.url,
+                        profileImageURL: URL(string: diaryResponseDTO.member.profileImage),
+                        diaryImageURL: nil,
                         isCurrentUser: UserManager.shared.id == diaryResponseDTO.member.memberId
                     )
                 }

--- a/GraceLog/Source/Data/Repository/DefaultUserRepository.swift
+++ b/GraceLog/Source/Data/Repository/DefaultUserRepository.swift
@@ -22,7 +22,7 @@ final class DefaultUserRepository: UserRepository {
                     id: responseDTO.memberId,
                     name: responseDTO.name,
                     nickname: responseDTO.nickname,
-                    profileImageURL: responseDTO.profileImage,
+                    profileImageURL: URL(string: responseDTO.profileImage),
                     email: responseDTO.email,
                     message: responseDTO.message
                 )
@@ -52,7 +52,7 @@ final class DefaultUserRepository: UserRepository {
                 id: responseDTO.memberId,
                 name: responseDTO.name,
                 nickname: responseDTO.nickname,
-                profileImageURL: responseDTO.profileImage,
+                profileImageURL: URL(string: responseDTO.profileImage),
                 email: responseDTO.email,
                 message: responseDTO.message
             )

--- a/GraceLog/Source/Domain/Entity/Comment.swift
+++ b/GraceLog/Source/Domain/Entity/Comment.swift
@@ -8,10 +8,11 @@
 import Foundation
 
 struct Comment {
-    let id: String
+    let id: Int
     let authorName: String
     let createdAt: String
     let profileImageURL: URL?
     let comment: String
+    let replyCount: Int
     let subComments: [Comment]
 }

--- a/GraceLog/Source/Domain/Protocol/CommentRepository.swift
+++ b/GraceLog/Source/Domain/Protocol/CommentRepository.swift
@@ -1,0 +1,14 @@
+//
+//  CommentRepository.swift
+//  GraceLog
+//
+//  Created by 이건준 on 1/29/26.
+//
+
+import RxSwift
+
+protocol CommentRepository {
+    func fetchCommentList(postId: Int) -> Single<[Comment]>
+    func fetchReplyList(parentId: Int) -> Single<[Comment]>
+    func createComment(request: CreateCommentRequestDTO, postId: Int) -> Single<GLEmptyResponse>
+}

--- a/GraceLog/Source/Domain/Usecase/Comment/DefaultCommentUseCase.swift
+++ b/GraceLog/Source/Domain/Usecase/Comment/DefaultCommentUseCase.swift
@@ -5,67 +5,61 @@
 //  Created by 이건준 on 7/19/25.
 //
 
+import RxSwift
 import RxRelay
 
 final class DefaultCommentUseCase: CommentUseCase {
+    private let commentRepository: CommentRepository
+    private let postId: Int
+    private let disposeBag = DisposeBag()
     var commentList = BehaviorRelay<[Comment]>(value: [])
+    let repliesByParent = BehaviorRelay<[Int: [Comment]]>(value: [:])
+    var commentError = PublishRelay<Error>()
     
-    func fetchCommentList() {
-        commentList.accept([
-            Comment(
-                id: "1",
-                authorName: "이건준",
-                createdAt: "조금 전",
-                profileImageURL: URL(string: ""),
-                comment: "지금도 매일 감사하고 있어? 요즘에는 하나님과 너의 삶과 관련해서 어떤 얘기를 나눠?",
-                subComments: [
-                    Comment(
-                        id: "5",
-                        authorName: "승렬",
-                        createdAt: "방금",
-                        profileImageURL: URL(string: ""),
-                        comment: "오늘 새벽예배 말씀에서 들었어! 감사는 우리의 믿음이랑 직결되는 부분이라고 해~",
-                        subComments: []
-                    )
-                ]
-            ),
-            Comment(
-                id: "2",
-                authorName: "신범철",
-                createdAt: "조금 전",
-                profileImageURL: URL(string: ""),
-                comment: "하루 하루 작은 것에 감사함을 느끼기 시작했어~ 이 부분을 기도하면서 하나님과 나누는 중이야. ",
-                subComments: []
-            ),
-            Comment(
-                id: "3",
-                authorName: "이상준",
-                createdAt: "25주 전",
-                profileImageURL: URL(string: ""),
-                comment: "그거 정말 잘됐다!! 너 처음에 불평만 하고 아무것도 안하려고 했잖아 ㅋㅋㅋ. 소식 들으니 좋네~ 계속해서 주님께 들고 나아가보자. 절대로 너가 했다고 생각하지 말고!! 늘 겸손하기~",
-                subComments: [
-                    Comment(
-                        id: "6",
-                        authorName: "문진우",
-                        createdAt: "2초 전",
-                        profileImageURL: URL(string: ""),
-                        comment: "매순간 순간마다 감사하면서 살아가는 삶을 살고 싶어! 특별히 사랑하는 예수님과 함께",
-                        subComments: []
-                    ),
-                    Comment(
-                        id: "7",
-                        authorName: "김규리",
-                        createdAt: "6초 전",
-                        profileImageURL: URL(string: ""),
-                        comment: "지금도 매일 감사하고 있어? 요즘에는 하나님과 너의 삶과 관련해서 어떤 얘기를 나눠?",
-                        subComments: []
-                    )
-                ]
-            )
-        ])
+    init(commentRepository: CommentRepository, postId: Int) {
+        self.commentRepository = commentRepository
+        self.postId = postId
     }
     
-    func createComment(_ comment: String) {
-        print("생성된 댓글: \(comment)")
+    func fetchCommentList() {
+        commentRepository.fetchCommentList(postId: postId)
+            .subscribe(with: self, onSuccess: { owner, comments in
+                owner.commentList.accept(comments)
+            }, onFailure: { owner, error in
+                owner.commentError.accept(error)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func fetchReplyList(parentId: Int) {
+        commentRepository.fetchReplyList(parentId: parentId)
+            .subscribe(with: self, onSuccess: { owner, replies in
+                var dict = owner.repliesByParent.value
+                dict[parentId] = replies
+                owner.repliesByParent.accept(dict)
+            }, onFailure: { owner, error in
+                owner.commentError.accept(error)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func clearReplies(parentId: Int) {
+        var dict = repliesByParent.value
+        dict[parentId] = nil
+        repliesByParent.accept(dict)
+    }
+    
+    func createComment(_ comment: String, parentId: Int) {
+        commentRepository.createComment(
+            request: .init(content: comment, parentId: parentId),
+            postId: postId
+        )
+        .subscribe(with: self, onSuccess: { owner, _ in
+            owner.fetchReplyList(parentId: parentId)
+        }, onFailure: { owner, error in
+            owner.commentError.accept(error)
+        })
+        .disposed(by: disposeBag)
+        
     }
 }

--- a/GraceLog/Source/Domain/Usecase/Comment/Protocol/CommentUseCase.swift
+++ b/GraceLog/Source/Domain/Usecase/Comment/Protocol/CommentUseCase.swift
@@ -9,7 +9,11 @@ import RxRelay
 
 protocol CommentUseCase {
     var commentList: BehaviorRelay<[Comment]> { get }
+    var repliesByParent: BehaviorRelay<[Int: [Comment]]> { get }
+    var commentError: PublishRelay<Error> { get }
     
     func fetchCommentList()
-    func createComment(_ comment: String)
+    func fetchReplyList(parentId: Int)
+    func createComment(_ comment: String, parentId: Int)
+    func clearReplies(parentId: Int)
 }

--- a/GraceLog/Source/Domain/Usecase/Diary/DefaultDiaryDetailsUseCase.swift
+++ b/GraceLog/Source/Domain/Usecase/Diary/DefaultDiaryDetailsUseCase.swift
@@ -47,11 +47,6 @@ final class DefaultDiaryDetailsUseCase: DiaryDetailsUseCase {
             .subscribe(onSuccess: { diary in
                 self.communityId = diary.communityId
                 self.memberId = diary.user.id
-                
-                if let createdAt = diary.createdAt {
-                    self.fetchDateRangeDiaryList(date: createdAt)
-                }
-                
                 self.diary.accept(diary)
             }, onFailure: { error in
                 self.error.accept(error)

--- a/GraceLog/Source/Presentation/CoreTab/DiaryScene/Coordinator/DiaryDetailsCoordinator.swift
+++ b/GraceLog/Source/Presentation/CoreTab/DiaryScene/Coordinator/DiaryDetailsCoordinator.swift
@@ -34,7 +34,7 @@ final class DiaryDetailsCoordinator: Coordinator {
     func showCommentBottomSheet() {
         let commentBottomSheetVC = CommentBottomSheetViewController(
             reactor: CommentBottomSheetViewReactor(
-                usecase: DefaultCommentUseCase()
+                usecase: DefaultCommentUseCase(commentRepository: DefaultCommentRepository(network: .init()), postId: diaryId)
             )
         )
         self.navigationController.present(commentBottomSheetVC, animated: true)

--- a/GraceLog/Source/Presentation/CoreTab/DiaryScene/DataSource/CommentSection.swift
+++ b/GraceLog/Source/Presentation/CoreTab/DiaryScene/DataSource/CommentSection.swift
@@ -11,7 +11,7 @@ struct CommentSection: AnimatableSectionModelType {
     var mainComment: CommentState
     var subComments: [CommentItem]
     
-    var identity: String {
+    var identity: Int {
         return mainComment.item.identity
     }
     
@@ -33,6 +33,7 @@ struct CommentSection: AnimatableSectionModelType {
 struct CommentState {
     let item: CommentItem
     var isFolder: Bool
+    let replyCount: Int
 }
 
 struct CommentItem {
@@ -44,7 +45,7 @@ struct CommentItem {
 }
 
 extension CommentItem: IdentifiableType, Equatable {
-    var identity: String {
+    var identity: Int {
         return id
     }
     

--- a/GraceLog/Source/Presentation/CoreTab/DiaryScene/Reactor/CommentBottomSheetViewReactor.swift
+++ b/GraceLog/Source/Presentation/CoreTab/DiaryScene/Reactor/CommentBottomSheetViewReactor.swift
@@ -6,91 +6,169 @@
 //
 
 import ReactorKit
+import RxSwift
 
 final class CommentBottomSheetViewReactor: Reactor {
+    
+    // MARK: - Dependency
     private let usecase: CommentUseCase
+    
+    // MARK: - Initial State
     let initialState: State
     
+    // MARK: - Action
     enum Action {
-        case didTapFolderButton((Int, Bool)?)
-        case didEditButton(String)
+        case viewDidLoad
+        case didTapToggleReplies(parentId: Int)
+        case didEditReplyButton(parentId: Int)
+        case didTapCreateButton(String)
     }
     
+    // MARK: - Mutation
     enum Mutation {
-        case setCommentList([CommentSection])
+        case setParents([Comment])
+        case setReplies([Int: [Comment]])
+        case setExpanded(Set<Int>)
+        case setSelectedParentId(Int?)
+        case setError(Error)
     }
     
+    // MARK: - State
     struct State {
-        @Pulse var commentList: [CommentSection]
+        var parents: [Comment] = []
+        var repliesByParent: [Int: [Comment]] = [:]
+        var expandedParentIds: Set<Int> = []
+        
+        @Pulse var commentList: [CommentSection] = []
+        @Pulse var selectedParentCommentID: Int?
+        @Pulse var error: Error?
     }
     
+    // MARK: - Init
     init(usecase: CommentUseCase) {
         self.usecase = usecase
-        self.initialState = State(
-            commentList: []
-        )
-        usecase.fetchCommentList()
+        self.initialState = State()
     }
-}
-
-extension CommentBottomSheetViewReactor {
+    
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .didTapFolderButton(let result):
-            guard let (sectionIndex, isFolder) = result else {
+            
+        case .viewDidLoad:
+            usecase.fetchCommentList()
+            return .empty()
+            
+        case .didTapToggleReplies(let parentId):
+            var expanded = currentState.expandedParentIds
+            
+            if expanded.contains(parentId) {
+                expanded.remove(parentId)
+                return .just(.setExpanded(expanded))
+            } else {
+                expanded.insert(parentId)
+                usecase.fetchReplyList(parentId: parentId)
+                return .just(.setExpanded(expanded))
+            }
+            
+        case .didEditReplyButton(let parentId):
+            return .just(.setSelectedParentId(parentId))
+            
+        case .didTapCreateButton(let comment):
+            guard let parentId = currentState.selectedParentCommentID else {
                 return .empty()
             }
-            var currentCommentList = currentState.commentList
-            currentCommentList[sectionIndex].mainComment.isFolder = isFolder
-            
-            return .just(.setCommentList(currentCommentList))
-        case .didEditButton(let comment):
-            usecase.createComment(comment)
+            usecase.createComment(comment, parentId: parentId)
             return .empty()
         }
     }
     
     
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
-        let commentMutation = usecase.commentList
-            .map { commentList -> [CommentSection] in
-                commentList.map {
-                    CommentSection(
-                        mainComment: CommentState(
-                            item: CommentItem(
-                                id: $0.id,
-                                comment: $0.comment,
-                                profileImageURL: $0.profileImageURL,
-                                authorName: $0.authorName,
-                                editedDate: $0.createdAt
-                            ),
-                            isFolder: false
-                        ),
-                        subComments: $0.subComments.map {
-                            CommentItem(
-                                id: $0.id,
-                                comment: $0.comment,
-                                profileImageURL: $0.profileImageURL,
-                                authorName: $0.authorName,
-                                editedDate: $0.createdAt
-                            )
-                        }
-                    )
-                }
-            }
-            .map { Mutation.setCommentList($0) }
-        return Observable.merge(commentMutation, mutation)
+        let parentsStream = usecase.commentList
+            .map { Mutation.setParents($0) }
+        
+        let repliesStream = usecase.repliesByParent
+            .map { Mutation.setReplies($0) }
+        
+        let errorStream = usecase.commentError
+            .map { Mutation.setError($0) }
+        
+        return Observable.merge(
+            mutation,
+            parentsStream,
+            repliesStream,
+            errorStream
+        )
     }
     
     func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
         
         switch mutation {
-        case .setCommentList(let commentList):
-            newState.commentList = commentList
+            
+        case .setParents(let parents):
+            newState.parents = parents
+            
+        case .setReplies(let replies):
+            newState.repliesByParent = replies
+            
+        case .setExpanded(let expanded):
+            newState.expandedParentIds = expanded
+            
+        case .setSelectedParentId(let parentId):
+            newState.selectedParentCommentID = parentId
+            
+        case .setError(let error):
+            newState.error = error
         }
+        
+        newState.commentList = Self.buildSections(
+            parents: newState.parents,
+            repliesDict: newState.repliesByParent,
+            expanded: newState.expandedParentIds
+        )
         
         return newState
     }
-    
+}
+
+// MARK: - Section Builder
+extension CommentBottomSheetViewReactor {
+    private static func buildSections(
+        parents: [Comment],
+        repliesDict: [Int: [Comment]],
+        expanded: Set<Int>
+    ) -> [CommentSection] {
+        
+        return parents.map { parent in
+            let isExpanded = expanded.contains(parent.id)
+            let replies = isExpanded ? (repliesDict[parent.id] ?? []) : []
+            
+            let parentItem = CommentItem(
+                id: parent.id,
+                comment: parent.comment,
+                profileImageURL: parent.profileImageURL,
+                authorName: parent.authorName,
+                editedDate: parent.createdAt
+            )
+            
+            let subItems: [CommentItem] = replies.map {
+                CommentItem(
+                    id: $0.id,
+                    comment: $0.comment,
+                    profileImageURL: $0.profileImageURL,
+                    authorName: $0.authorName,
+                    editedDate: $0.createdAt
+                )
+            }
+            
+            return CommentSection(
+                mainComment: CommentState(
+                    item: parentItem,
+                    isFolder: !isExpanded,
+                    replyCount: parent.replyCount
+                ),
+                subComments: subItems
+            )
+        }
+    }
 }

--- a/GraceLog/Source/Presentation/CoreTab/DiaryScene/Reactor/DiaryDetailsViewReactor.swift
+++ b/GraceLog/Source/Presentation/CoreTab/DiaryScene/Reactor/DiaryDetailsViewReactor.swift
@@ -14,10 +14,10 @@ final class DiaryDetailsViewReactor: Reactor {
     var initialState: State
     
     enum Action {
-        case fetchDiary(Int)
+        case fetchDiary(Date)
         case fetchDateRangeDiaryList(Date)
         case didTapBackButton
-        case didTapLikeButton(Int)
+        case didTapLikeButton
         case didTapCommentButton(Int)
     }
     
@@ -30,6 +30,7 @@ final class DiaryDetailsViewReactor: Reactor {
     struct State {
         @Pulse var diary: DiaryDetails?
         @Pulse var dateRangeDiaries: [DiaryDetails]
+        @Pulse var editedDateList: Set<Date>
         @Pulse var error: Error?
     }
     
@@ -41,7 +42,8 @@ final class DiaryDetailsViewReactor: Reactor {
         self.usecase = usecase
         
         self.initialState = State(
-            dateRangeDiaries: []
+            dateRangeDiaries: [],
+            editedDateList: []
         )
     }
 }
@@ -49,15 +51,19 @@ final class DiaryDetailsViewReactor: Reactor {
 extension DiaryDetailsViewReactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .fetchDiary(let diaryId):
-            usecase.fetchDiaryDetails(diaryId: diaryId)
+        case .fetchDiary(let selectedDate):
+            guard let selectedDiary = currentState.dateRangeDiaries.first(where: { $0.createdAt == selectedDate }) else {
+                return .empty()
+            }
+            usecase.fetchDiaryDetails(diaryId: selectedDiary.diaryId)
         case .fetchDateRangeDiaryList(let date):
             usecase.fetchDateRangeDiaryList(
                 date: date
             )
         case .didTapBackButton:
             coordinator.popViewController()
-        case .didTapLikeButton(let diaryID):
+        case .didTapLikeButton:
+            guard let diaryID = currentState.diary?.diaryId else { return .empty() }
             usecase.toggleDiaryLike(id: diaryID)
             return .just(.toggleLike)
         case .didTapCommentButton:
@@ -74,11 +80,11 @@ extension DiaryDetailsViewReactor {
             newState.diary = diary
         case .setDateRangeDiaryList(let diaryList):
             newState.dateRangeDiaries = diaryList
+            newState.editedDateList = Set(diaryList.compactMap { $0.createdAt })
         case .toggleLike:
             if var diary = newState.diary {
                 diary.likeByMe.toggle()
-                diary.likeCount += diary.likeByMe ? 1 : -1
-                diary.likeCount = max(0, diary.likeCount)
+                diary.likeCount = max(0, diary.likeByMe ? diary.likeCount + 1 : diary.likeCount - 1)
                 newState.diary = diary
             }
         case .setError(let error):

--- a/GraceLog/Source/Presentation/CoreTab/DiaryScene/View/DiaryDetails/DiaryDetailsView.swift
+++ b/GraceLog/Source/Presentation/CoreTab/DiaryScene/View/DiaryDetails/DiaryDetailsView.swift
@@ -17,7 +17,6 @@ final class DiaryDetailsView: UIView {
     private let backgroundImageView = UIImageView().then {
         $0.contentMode = .scaleAspectFill
         $0.layer.masksToBounds = true
-        $0.clipsToBounds = true
         $0.isUserInteractionEnabled = true
     }
     
@@ -30,7 +29,7 @@ final class DiaryDetailsView: UIView {
     
     private let mainStackView = UIStackView().then {
         $0.axis = .vertical
-        $0.spacing = 0
+        $0.spacing = 40
         $0.alignment = .center
         $0.distribution = .fill
     }
@@ -143,9 +142,7 @@ final class DiaryDetailsView: UIView {
         ].forEach { mainStackView.addArrangedSubview($0) }
         
         mainStackView.setCustomSpacing(12, after: categoryLabel)
-        mainStackView.setCustomSpacing(40, after: titleLabel)
         mainStackView.setCustomSpacing(24, after: descriptionLabel)
-        mainStackView.setCustomSpacing(40, after: moreButton)
     }
     
     private func setupConstraints() {
@@ -243,10 +240,7 @@ extension DiaryDetailsView {
             title: expanded ? "접기" : "이어서 더보기",
             imageName: expanded ? "chevron_up" : "chevron_down"
         )
-        UIView.animate(
-            withDuration: 0.3,
-            delay: 0.03,
-            options: [.curveEaseInOut]
-        ) { self.descriptionLabel.sizeToFit() }
+        
+        descriptionLabel.sizeToFit()
     }
 }

--- a/GraceLog/Source/Presentation/CoreTab/DiaryScene/ViewController/Comment/CommentBottomSheetViewController.swift
+++ b/GraceLog/Source/Presentation/CoreTab/DiaryScene/ViewController/Comment/CommentBottomSheetViewController.swift
@@ -58,6 +58,12 @@ final class CommentBottomSheetViewController: GraceLogBaseViewController<Comment
     
     override func bind(reactor: CommentBottomSheetViewReactor) {
         super.bind(reactor: reactor)
+        rx.methodInvoked(#selector(UIViewController.viewDidLoad))
+            .take(1)
+            .map { _ in CommentBottomSheetViewReactor.Action.viewDidLoad }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         commentTableView.rx.setDelegate(self).disposed(by: disposeBag)
         
         commentDataSource = RxTableViewSectionedAnimatedDataSource(configureCell: { dataSource, tableView, indexPath, item in
@@ -75,13 +81,6 @@ final class CommentBottomSheetViewController: GraceLogBaseViewController<Comment
             .asDriver(onErrorJustReturn: [])
             .drive(commentTableView.rx.items(dataSource: commentDataSource))
             .disposed(by: disposeBag)
-        
-        commentEditView.commentSendButton.rx.tap
-            .throttle(.milliseconds(300), scheduler: ConcurrentDispatchQueueScheduler(qos: .default))
-            .withLatestFrom(commentEditView.commentTextField.rx.text.orEmpty)
-            .map { CommentBottomSheetViewReactor.Action.didEditButton($0) }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
     }
 }
 
@@ -91,7 +90,8 @@ extension CommentBottomSheetViewController: UITableViewDelegate {
         let sectionedModel = commentDataSource[section]
         let mainComment = sectionedModel.mainComment
         let item = mainComment.item
-        let isFolder = mainComment.isFolder
+        
+        let parentId = item.id
         
         headerView.configureUI(
             profileImageURL: item.profileImageURL,
@@ -100,18 +100,25 @@ extension CommentBottomSheetViewController: UITableViewDelegate {
             comment: item.comment
         )
         
-        headerView.commentToggleButton.currentState = isFolder ? .folded(replyCount: sectionedModel.subComments.count) : .unfolded
+        headerView.commentToggleButton.currentState =
+        mainComment.isFolder
+        ? .folded(replyCount: sectionedModel.mainComment.replyCount)
+        : .unfolded
         
         headerView.commentToggleButton.rx.tapGesture().when(.recognized)
             .throttle(.milliseconds(500), scheduler: ConcurrentDispatchQueueScheduler(qos: .default))
             .subscribe(with: self) { owner, _ in
-                let isFolder = (headerView.commentToggleButton.currentState == .unfolded)
-                
+                owner.reactor?.action.onNext(.didTapToggleReplies(parentId: parentId))
+            }
+            .disposed(by: headerView.disposeBag)
+        
+        headerView.replyButton.rx.tap
+            .throttle(.milliseconds(500), scheduler: ConcurrentDispatchQueueScheduler(qos: .default))
+            .subscribe(with: self) { owner, _ in
+                owner.reactor?.action.onNext(.didEditReplyButton(parentId: parentId))
                 DispatchQueue.main.async {
-                    headerView.commentToggleButton.currentState = isFolder ? .folded(replyCount: sectionedModel.subComments.count) : .unfolded
+                    owner.commentEditView.commentTextField.becomeFirstResponder()
                 }
-                
-                owner.reactor?.action.onNext(.didTapFolderButton((section, isFolder)))
             }
             .disposed(by: headerView.disposeBag)
         

--- a/GraceLog/Source/Presentation/CoreTab/DiaryScene/ViewController/DiaryDetailsViewController.swift
+++ b/GraceLog/Source/Presentation/CoreTab/DiaryScene/ViewController/DiaryDetailsViewController.swift
@@ -129,12 +129,8 @@ final class DiaryDetailsViewController: GraceLogBaseViewController<DiaryDetailsV
             .disposed(by: disposeBag)
         
         diaryDetailsView.likeButton.rx.tap
-            .do(onNext: { _ in
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            })
-            .throttle(.milliseconds(500), scheduler: ConcurrentDispatchQueueScheduler.init(qos: .default))
-            .compactMap { reactor.currentState.diary?.diaryId }
-            .map { DiaryDetailsViewReactor.Action.didTapLikeButton($0) }
+            .throttle(.milliseconds(300), scheduler: ConcurrentDispatchQueueScheduler.init(qos: .default))
+            .map { DiaryDetailsViewReactor.Action.didTapLikeButton }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
@@ -144,10 +140,10 @@ final class DiaryDetailsViewController: GraceLogBaseViewController<DiaryDetailsV
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        let diaryObservable = reactor.pulse(\.$diary).share(replay: 1)
+        let diaryObservable = reactor.pulse(\.$diary).share(replay: 1).compactMap { $0 }
         
         diaryObservable
-            .compactMap { $0 }
+            .take(1)
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, diary in
                 if diary.user.id == UserManager.shared.id {
@@ -160,12 +156,18 @@ final class DiaryDetailsViewController: GraceLogBaseViewController<DiaryDetailsV
             .disposed(by: disposeBag)
         
         diaryObservable
-            .compactMap { $0 }
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, diary in
                 if let createdAt = diary.createdAt {
                     owner.calendarButton.configuration?.title = DateFormatterFactory.toYearMonthString(from: createdAt)
-                    owner.calendarView.select(createdAt)
+                    let alreadySelectedSameDay = {
+                        guard let selected = owner.calendarView.selectedDate else { return false }
+                        return Calendar.current.isDate(selected, inSameDayAs: createdAt)
+                    }()
+                    
+                    if !alreadySelectedSameDay {
+                        owner.calendarView.select(createdAt)
+                    }
                 }
                 
                 owner.diaryDetailsView.configure(
@@ -182,10 +184,12 @@ final class DiaryDetailsViewController: GraceLogBaseViewController<DiaryDetailsV
             }
             .disposed(by: disposeBag)
         
-        reactor.pulse(\.$dateRangeDiaries)
+        reactor.pulse(\.$editedDateList)
             .asDriver(onErrorJustReturn: [])
             .drive(with: self) { owner, _ in
-                owner.calendarView.reloadData()
+                UIView.performWithoutAnimation {
+                    owner.calendarView.reloadData()
+                }
             }
             .disposed(by: disposeBag)
         
@@ -227,11 +231,10 @@ extension DiaryDetailsViewController: FSCalendarDelegate, FSCalendarDataSource {
     
     /// 감사일기가 작성된 날짜 마커
     func calendar(_ calendar: FSCalendar, numberOfEventsFor date: Date) -> Int {
-        guard let diaryList = reactor?.currentState.dateRangeDiaries else { return 0 }
+        guard let diaryList = reactor?.currentState.editedDateList else { return 0 }
         
         let hasEvent = diaryList.contains(where: {
-            guard let createdAt = $0.createdAt else { return false }
-            return Calendar.current.isDate(createdAt, inSameDayAs: date)
+            return Calendar.current.isDate($0, inSameDayAs: date)
         })
         
         return hasEvent ? 1 : 0
@@ -239,22 +242,20 @@ extension DiaryDetailsViewController: FSCalendarDelegate, FSCalendarDataSource {
     
     /// 날짜 선택 가능 여부 결정
     func calendar(_ calendar: FSCalendar, shouldSelect date: Date, at monthPosition: FSCalendarMonthPosition) -> Bool {
-        guard let diaryList = reactor?.currentState.dateRangeDiaries else { return false }
+        guard let diaryList = reactor?.currentState.editedDateList else { return false }
         
         let hasEvent = diaryList.contains(where: {
-            guard let createdAt = $0.createdAt else { return false }
-            return Calendar.current.isDate(createdAt, inSameDayAs: date)
+            return Calendar.current.isDate($0, inSameDayAs: date)
         })
         
         return hasEvent
     }
     
     func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
-        if let selectedDiary = reactor?.currentState.dateRangeDiaries.first(where: {
-            guard let createdAt = $0.createdAt else { return false }
-            return Calendar.current.isDate(createdAt, inSameDayAs: date)
-        }) {
-            reactor?.action.onNext(.fetchDiary(selectedDiary.diaryId))
-        }
+        guard let selectedDate = reactor?.currentState.editedDateList.first(where: {
+            Calendar.current.isDate($0, inSameDayAs: date)
+        }) else { return }
+        
+        reactor?.action.onNext(.fetchDiary(selectedDate))
     }
 }


### PR DESCRIPTION
## 작업 내용

- [ ] 댓글 / 대댓글 구조를 ReactorKit 기반 단방향 데이터 흐름으로 재설계
- [ ] 부모 댓글과 대댓글을 분리 조회하는 API 구조에 맞춰 상태 관리 로직 구현
- [ ] 대댓글 펼침/접힘 상태를 UI 책임으로 두고 Reactor State에서 관리하도록 수정
 - [ ] expandedParentIds를 통해 어떤 부모 댓글이 펼쳐져 있는지 추적
 - [ ] 대댓글은 펼칠 때만 API 호출하도록 하여 불필요한 네트워크 요청 방지
 - [ ] 댓글 목록과 대댓글 목록을 조합해 CommentSection 단일 배열로 UI에 전달
 - [ ] RxDataSources를 활용해 댓글 / 대댓글 렌더링 구조 정리
 - [ ] 접힌 상태에서도 대댓글 개수를 표시하기 위해 replyCount 기반 구조 적용


## 화면 (Optional)
- 댓글 목록 진입 시 부모 댓글만 노출
- 특정 댓글의 “답글 n개” 버튼 탭 시 해당 댓글의 대댓글만 비동기 로드 후 펼쳐짐
- 다시 접을 경우 대댓글 셀 제거 후 부모 댓글만 유지
- 대댓글 작성 버튼 탭 시 선택된 부모 댓글 기준으로 입력 포커스 이동


<br/><br/><br/>
## 고민점 및 해결 방법 (Optional)
### 1. 댓글 / 대댓글 API가 분리된 구조에서 상태 관리 방식
문제
- 부모 댓글과 대댓글이 서로 다른 API로 내려와 하나의 배열로 UI를 구성하기 어려웠음

해결
- UseCase에서는 부모 댓글과 대댓글을 각각 관리
- Reactor에서 두 스트림을 조합해 최종 CommentSection 배열 생성
- 펼침 여부(expandedParentIds)는 UI 상태이므로 Reactor State에서만 관리

### 2. 접힌 상태에서도 대댓글 개수 표시 문제
문제
- 대댓글을 펼치기 전에는 실제 subComments.count를 알 수 없음

해결
- 도메인 모델에 replyCount 개념을 분리하여 “요약 정보”와 “실제 데이터”를 구분
- UI 모델(CommentItem)에는 replyCount를 optional로 전달해 부모 댓글에서만 사용

### 3. RxDataSources + ReactorKit 조합에서 무한 방출/프리징 이슈
문제
- combineLatest와 @Pulse를 혼용하면서 예상치 못한 상태 순환 발생

해결
- UI 상태(expandedParentIds) 변경은 Mutation → Reduce 단방향으로만 흐르도록 제한
- State를 다시 참조하는 로직 제거
- Section 생성 로직을 순수 함수로 분리해 사이드 이펙트 제거
