### PR TITLE
Feat/communitygroup

### DIFF
--- a/GraceLog.xcodeproj/project.pbxproj
+++ b/GraceLog.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		70CBC73B2E8427400037C613 /* ProfileItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CBC73A2E8427400037C613 /* ProfileItem.swift */; };
 		70CBC7602E92602A0037C613 /* CommunityRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CBC75F2E92602A0037C613 /* CommunityRoom.swift */; };
 		70D73E3A2F003CEA0045D531 /* CreateCommunityCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D73E392F003CEA0045D531 /* CreateCommunityCoordinator.swift */; };
+		70D73E8C2F0278620045D531 /* CommunityGroupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D73E8B2F0278620045D531 /* CommunityGroupCoordinator.swift */; };
 		70F0061A2E0EC12C00228C70 /* DiaryTimelineCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F006192E0EC12C00228C70 /* DiaryTimelineCollectionViewCell.swift */; };
 		88C9F4B2C850546A45083619 /* Pods_GraceLog_GraceLogUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0638CA878A08BDCEFDE7EC10 /* Pods_GraceLog_GraceLogUITests.framework */; };
 		DE042C3D2E93FCB30089E20F /* DiaryDetailsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE042C3C2E93FCB30089E20F /* DiaryDetailsUseCase.swift */; };
@@ -334,6 +335,7 @@
 		70CBC73A2E8427400037C613 /* ProfileItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileItem.swift; sourceTree = "<group>"; };
 		70CBC75F2E92602A0037C613 /* CommunityRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityRoom.swift; sourceTree = "<group>"; };
 		70D73E392F003CEA0045D531 /* CreateCommunityCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCommunityCoordinator.swift; sourceTree = "<group>"; };
+		70D73E8B2F0278620045D531 /* CommunityGroupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityGroupCoordinator.swift; sourceTree = "<group>"; };
 		70F006192E0EC12C00228C70 /* DiaryTimelineCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryTimelineCollectionViewCell.swift; sourceTree = "<group>"; };
 		8A5653D885A3CC815C05106B /* Pods-GraceLogUseCaseTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GraceLogUseCaseTests.debug.xcconfig"; path = "Target Support Files/Pods-GraceLogUseCaseTests/Pods-GraceLogUseCaseTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9EDDF4DA9FBD1D0DC053E39F /* Pods-GraceLog.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GraceLog.debug.xcconfig"; path = "Target Support Files/Pods-GraceLog/Pods-GraceLog.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1361,6 +1363,7 @@
 			children = (
 				DE3BFCE32D059E970076426D /* SearchCoordinator.swift */,
 				70D73E392F003CEA0045D531 /* CreateCommunityCoordinator.swift */,
+				70D73E8B2F0278620045D531 /* CommunityGroupCoordinator.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -1930,6 +1933,7 @@
 				DE2387302E07E46300893D8C /* HomeMyViewReactor.swift in Sources */,
 				DE9A1FD02D6C87E60044F655 /* HomeCommunityDateHeaderView.swift in Sources */,
 				DEACFE682E0D04B900AD4222 /* HomeCommunityListCollectionViewCell.swift in Sources */,
+				70D73E8C2F0278620045D531 /* CommunityGroupCoordinator.swift in Sources */,
 				DE23873B2E0AD95F00893D8C /* HomePastDiaryCollectionViewCell.swift in Sources */,
 				709CBB6D2E2B8CA100F68457 /* CommentToggleButton.swift in Sources */,
 				DED558962DBE576A00137B10 /* Const.swift in Sources */,

--- a/GraceLog.xcodeproj/project.pbxproj
+++ b/GraceLog.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		70CBC73B2E8427400037C613 /* ProfileItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CBC73A2E8427400037C613 /* ProfileItem.swift */; };
 		70CBC7602E92602A0037C613 /* CommunityRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CBC75F2E92602A0037C613 /* CommunityRoom.swift */; };
 		70D73E3A2F003CEA0045D531 /* CreateCommunityCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D73E392F003CEA0045D531 /* CreateCommunityCoordinator.swift */; };
+		70D73E8C2F0278620045D531 /* CommunityGroupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D73E8B2F0278620045D531 /* CommunityGroupCoordinator.swift */; };
 		70F0061A2E0EC12C00228C70 /* DiaryTimelineCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F006192E0EC12C00228C70 /* DiaryTimelineCollectionViewCell.swift */; };
 		88C9F4B2C850546A45083619 /* Pods_GraceLog_GraceLogUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0638CA878A08BDCEFDE7EC10 /* Pods_GraceLog_GraceLogUITests.framework */; };
 		DE042C3D2E93FCB30089E20F /* DiaryDetailsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE042C3C2E93FCB30089E20F /* DiaryDetailsUseCase.swift */; };
@@ -353,6 +354,7 @@
 		70CBC73A2E8427400037C613 /* ProfileItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileItem.swift; sourceTree = "<group>"; };
 		70CBC75F2E92602A0037C613 /* CommunityRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityRoom.swift; sourceTree = "<group>"; };
 		70D73E392F003CEA0045D531 /* CreateCommunityCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCommunityCoordinator.swift; sourceTree = "<group>"; };
+		70D73E8B2F0278620045D531 /* CommunityGroupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityGroupCoordinator.swift; sourceTree = "<group>"; };
 		70F006192E0EC12C00228C70 /* DiaryTimelineCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryTimelineCollectionViewCell.swift; sourceTree = "<group>"; };
 		8A5653D885A3CC815C05106B /* Pods-GraceLogUseCaseTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GraceLogUseCaseTests.debug.xcconfig"; path = "Target Support Files/Pods-GraceLogUseCaseTests/Pods-GraceLogUseCaseTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9EDDF4DA9FBD1D0DC053E39F /* Pods-GraceLog.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GraceLog.debug.xcconfig"; path = "Target Support Files/Pods-GraceLog/Pods-GraceLog.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1405,6 +1407,7 @@
 			children = (
 				DE3BFCE32D059E970076426D /* SearchCoordinator.swift */,
 				70D73E392F003CEA0045D531 /* CreateCommunityCoordinator.swift */,
+				70D73E8B2F0278620045D531 /* CommunityGroupCoordinator.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -1990,6 +1993,7 @@
 				DE2387302E07E46300893D8C /* HomeMyViewReactor.swift in Sources */,
 				DE9A1FD02D6C87E60044F655 /* HomeCommunityDateHeaderView.swift in Sources */,
 				DEACFE682E0D04B900AD4222 /* HomeCommunityListCollectionViewCell.swift in Sources */,
+				70D73E8C2F0278620045D531 /* CommunityGroupCoordinator.swift in Sources */,
 				DE23873B2E0AD95F00893D8C /* HomePastDiaryCollectionViewCell.swift in Sources */,
 				709CBB6D2E2B8CA100F68457 /* CommentToggleButton.swift in Sources */,
 				DED558962DBE576A00137B10 /* Const.swift in Sources */,

--- a/GraceLog.xcodeproj/project.pbxproj
+++ b/GraceLog.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 		DE645D4E2F2CCA9B00C98B5A /* DiaryExistenceDatesRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645D4D2F2CCA9B00C98B5A /* DiaryExistenceDatesRequestDTO.swift */; };
 		DE645D502F2DAFD200C98B5A /* DiaryExistenceDateResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645D4F2F2DAFD200C98B5A /* DiaryExistenceDateResponseDTO.swift */; };
 		DE645D522F2DB06C00C98B5A /* DiaryExistenceDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645D512F2DB06C00C98B5A /* DiaryExistenceDate.swift */; };
+		DE645D822F31CAB100C98B5A /* CommunityGroupPresentationAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645D812F31CAB100C98B5A /* CommunityGroupPresentationAssembly.swift */; };
 		DE645D842F31CE3B00C98B5A /* DiaryLastPostDateResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645D832F31CE3B00C98B5A /* DiaryLastPostDateResponseDTO.swift */; };
 		DE645D862F3220B300C98B5A /* DiaryLastPostDateRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645D852F3220B300C98B5A /* DiaryLastPostDateRequestDTO.swift */; };
 		DE655B1F2DA1758F0073B4F7 /* CommonDivideTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE655B1E2DA1758F0073B4F7 /* CommonDivideTableViewCell.swift */; };
@@ -468,6 +469,7 @@
 		DE645D4D2F2CCA9B00C98B5A /* DiaryExistenceDatesRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryExistenceDatesRequestDTO.swift; sourceTree = "<group>"; };
 		DE645D4F2F2DAFD200C98B5A /* DiaryExistenceDateResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryExistenceDateResponseDTO.swift; sourceTree = "<group>"; };
 		DE645D512F2DB06C00C98B5A /* DiaryExistenceDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryExistenceDate.swift; sourceTree = "<group>"; };
+		DE645D812F31CAB100C98B5A /* CommunityGroupPresentationAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityGroupPresentationAssembly.swift; sourceTree = "<group>"; };
 		DE645D832F31CE3B00C98B5A /* DiaryLastPostDateResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryLastPostDateResponseDTO.swift; sourceTree = "<group>"; };
 		DE645D852F3220B300C98B5A /* DiaryLastPostDateRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryLastPostDateRequestDTO.swift; sourceTree = "<group>"; };
 		DE655B1E2DA1758F0073B4F7 /* CommonDivideTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonDivideTableViewCell.swift; sourceTree = "<group>"; };
@@ -1534,6 +1536,7 @@
 			isa = PBXGroup;
 			children = (
 				DE645B892F20462500C98B5A /* CreateCommunityPresentationAssembly.swift */,
+				DE645D812F31CAB100C98B5A /* CommunityGroupPresentationAssembly.swift */,
 			);
 			path = Community;
 			sourceTree = "<group>";
@@ -2133,6 +2136,7 @@
 				DE6459B12F10CBB800C98B5A /* NotificationCenterHandler.swift in Sources */,
 				70A97C6B2E2275B700F08DF6 /* DependencyContainer.swift in Sources */,
 				DE2700462D1EFD06005C9DCF /* SignInViewController.swift in Sources */,
+				DE645D822F31CAB100C98B5A /* CommunityGroupPresentationAssembly.swift in Sources */,
 				DE4D0F4A2E750EC300827EDE /* Announcement.swift in Sources */,
 				DE9A1FEC2D7C04C50044F655 /* Bundle.swift in Sources */,
 				DECCC6282EE582E000E893DB /* VideoResponseDTO.swift in Sources */,
@@ -2438,7 +2442,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.sangjun.GraceLog2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sangjun.GraceLog3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -2471,7 +2475,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.sangjun.GraceLog2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sangjun.GraceLog3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/GraceLog.xcodeproj/project.pbxproj
+++ b/GraceLog.xcodeproj/project.pbxproj
@@ -175,6 +175,12 @@
 		DE645A472F1B696800C98B5A /* AnnouncementPresentationAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645A462F1B696800C98B5A /* AnnouncementPresentationAssembly.swift */; };
 		DE645B872F1FA44800C98B5A /* CreateCommunityRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645B862F1FA44800C98B5A /* CreateCommunityRequestDTO.swift */; };
 		DE645B8A2F20462500C98B5A /* CreateCommunityPresentationAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645B892F20462500C98B5A /* CreateCommunityPresentationAssembly.swift */; };
+		DE645D4C2F2CC98800C98B5A /* MyActivityDiaryListRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645D4B2F2CC98800C98B5A /* MyActivityDiaryListRequestDTO.swift */; };
+		DE645D4E2F2CCA9B00C98B5A /* DiaryExistenceDatesRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645D4D2F2CCA9B00C98B5A /* DiaryExistenceDatesRequestDTO.swift */; };
+		DE645D502F2DAFD200C98B5A /* DiaryExistenceDateResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645D4F2F2DAFD200C98B5A /* DiaryExistenceDateResponseDTO.swift */; };
+		DE645D522F2DB06C00C98B5A /* DiaryExistenceDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645D512F2DB06C00C98B5A /* DiaryExistenceDate.swift */; };
+		DE645D842F31CE3B00C98B5A /* DiaryLastPostDateResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645D832F31CE3B00C98B5A /* DiaryLastPostDateResponseDTO.swift */; };
+		DE645D862F3220B300C98B5A /* DiaryLastPostDateRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645D852F3220B300C98B5A /* DiaryLastPostDateRequestDTO.swift */; };
 		DE655B1F2DA1758F0073B4F7 /* CommonDivideTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE655B1E2DA1758F0073B4F7 /* CommonDivideTableViewCell.swift */; };
 		DE655B212DA5EC480073B4F7 /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE655B202DA5EC480073B4F7 /* UILabel+Extension.swift */; };
 		DE66C2F32D941AF5009A983F /* DiaryShareTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE66C2F22D941AF5009A983F /* DiaryShareTableViewCell.swift */; };
@@ -458,6 +464,12 @@
 		DE645A462F1B696800C98B5A /* AnnouncementPresentationAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementPresentationAssembly.swift; sourceTree = "<group>"; };
 		DE645B862F1FA44800C98B5A /* CreateCommunityRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCommunityRequestDTO.swift; sourceTree = "<group>"; };
 		DE645B892F20462500C98B5A /* CreateCommunityPresentationAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCommunityPresentationAssembly.swift; sourceTree = "<group>"; };
+		DE645D4B2F2CC98800C98B5A /* MyActivityDiaryListRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyActivityDiaryListRequestDTO.swift; sourceTree = "<group>"; };
+		DE645D4D2F2CCA9B00C98B5A /* DiaryExistenceDatesRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryExistenceDatesRequestDTO.swift; sourceTree = "<group>"; };
+		DE645D4F2F2DAFD200C98B5A /* DiaryExistenceDateResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryExistenceDateResponseDTO.swift; sourceTree = "<group>"; };
+		DE645D512F2DB06C00C98B5A /* DiaryExistenceDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryExistenceDate.swift; sourceTree = "<group>"; };
+		DE645D832F31CE3B00C98B5A /* DiaryLastPostDateResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryLastPostDateResponseDTO.swift; sourceTree = "<group>"; };
+		DE645D852F3220B300C98B5A /* DiaryLastPostDateRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryLastPostDateRequestDTO.swift; sourceTree = "<group>"; };
 		DE655B1E2DA1758F0073B4F7 /* CommonDivideTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonDivideTableViewCell.swift; sourceTree = "<group>"; };
 		DE655B202DA5EC480073B4F7 /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		DE66C2F22D941AF5009A983F /* DiaryShareTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryShareTableViewCell.swift; sourceTree = "<group>"; };
@@ -1132,6 +1144,7 @@
 				70CBC73A2E8427400037C613 /* ProfileItem.swift */,
 				70CBC75F2E92602A0037C613 /* CommunityRoom.swift */,
 				DECCC6292EE5857500E893DB /* VideoInfo.swift */,
+				DE645D512F2DB06C00C98B5A /* DiaryExistenceDate.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -1613,6 +1626,9 @@
 				DE4237592EC20AB8006FAA7B /* LikeCountRequestDTO.swift */,
 				DE93B6F42ECDF6C000BCFB5D /* CommunityDiaryListRequestDTO.swift */,
 				DE645B862F1FA44800C98B5A /* CreateCommunityRequestDTO.swift */,
+				DE645D4B2F2CC98800C98B5A /* MyActivityDiaryListRequestDTO.swift */,
+				DE645D4D2F2CCA9B00C98B5A /* DiaryExistenceDatesRequestDTO.swift */,
+				DE645D852F3220B300C98B5A /* DiaryLastPostDateRequestDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -1628,6 +1644,8 @@
 				DE93B6F82ECDF97000BCFB5D /* CommunityResponseDTO.swift */,
 				DE93B6FC2ED061EB00BCFB5D /* DailyVerseResponseDTO.swift */,
 				DECCC6272EE582E000E893DB /* VideoResponseDTO.swift */,
+				DE645D4F2F2DAFD200C98B5A /* DiaryExistenceDateResponseDTO.swift */,
+				DE645D832F31CE3B00C98B5A /* DiaryLastPostDateResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1988,6 +2006,7 @@
 				DE597A6E2E26141100B2CB5B /* AuthPresentationAssembly.swift in Sources */,
 				DE93B6F72ECDF80100BCFB5D /* CommunityAPI.swift in Sources */,
 				0220A0752DE7F57000D045F7 /* ImagePickerManager.swift in Sources */,
+				DE645D862F3220B300C98B5A /* DiaryLastPostDateRequestDTO.swift in Sources */,
 				702D2B582E02B1F900D5E71E /* UITextField+Extension.swift in Sources */,
 				70CBC73B2E8427400037C613 /* ProfileItem.swift in Sources */,
 				702D2B702E07F35B00D5E71E /* DiarySettingView.swift in Sources */,
@@ -2034,6 +2053,7 @@
 				DEA80D8A2F04AC6B00216B1D /* DiaryReserveTimeView.swift in Sources */,
 				DE9A1FDC2D79AFFA0044F655 /* MyDiaryPreview.swift in Sources */,
 				70A97C682E226B3900F08DF6 /* DependencyInjector.swift in Sources */,
+				DE645D502F2DAFD200C98B5A /* DiaryExistenceDateResponseDTO.swift in Sources */,
 				DED558862DBE224300137B10 /* DefaultAuthRepository.swift in Sources */,
 				DE2700632D22D188005C9DCF /* DefaultUserRepository.swift in Sources */,
 				704815772DFEC53A009ECDBD /* GLUnderlineSegmentedControl.swift in Sources */,
@@ -2052,6 +2072,7 @@
 				02DC29822DDC29C000662D8A /* ProfileEditViewReactor.swift in Sources */,
 				DE645A452F1A44F300C98B5A /* ProfileEditPresentationAssembly.swift in Sources */,
 				02DC29832DDC29C000662D8A /* ProfileEditViewController.swift in Sources */,
+				DE645D4E2F2CCA9B00C98B5A /* DiaryExistenceDatesRequestDTO.swift in Sources */,
 				026656AB2DE7E9CA00541D96 /* NavigationBarUtil.swift in Sources */,
 				02DC29862DDC29C000662D8A /* MyInfoViewReactor.swift in Sources */,
 				70A97C512E196D4E00F08DF6 /* NavigationController.swift in Sources */,
@@ -2122,6 +2143,7 @@
 				DE069B9A2D53A884007C2066 /* DiaryViewController.swift in Sources */,
 				DED558762DBC73EC00137B10 /* TargetType.swift in Sources */,
 				DE655B1F2DA1758F0073B4F7 /* CommonDivideTableViewCell.swift in Sources */,
+				DE645D522F2DB06C00C98B5A /* DiaryExistenceDate.swift in Sources */,
 				DED5587D2DBC7B3100137B10 /* SignInRequestDTO.swift in Sources */,
 				DED5589F2DC4B12200137B10 /* KeychainAccessible.swift in Sources */,
 				DEF8D6742E1A91EF00685517 /* HomeCommunityUseCase.swift in Sources */,
@@ -2132,11 +2154,13 @@
 				DE069BA22D571485007C2066 /* HomeRecommendVideoTableViewCell.swift in Sources */,
 				DE4237502EBEE935006FAA7B /* DefaultDiaryRepository.swift in Sources */,
 				DE66C2F52D96B0E4009A983F /* DiaryViewReactor.swift in Sources */,
+				DE645D4C2F2CC98800C98B5A /* MyActivityDiaryListRequestDTO.swift in Sources */,
 				DE66C2F32D941AF5009A983F /* DiaryShareTableViewCell.swift in Sources */,
 				DE645B8A2F20462500C98B5A /* CreateCommunityPresentationAssembly.swift in Sources */,
 				DE66C2F32D941AF5009A983F /* DiaryShareTableViewCell.swift in Sources */,
 				DEA80D9E2F050B3F00216B1D /* DefaultDailyVerseRepository.swift in Sources */,
 				DEACFE6A2E0F81DE00AD4222 /* HomeCommunityListSection.swift in Sources */,
+				DE645D842F31CE3B00C98B5A /* DiaryLastPostDateResponseDTO.swift in Sources */,
 				DE9A1FF62D7C07FE0044F655 /* HomePersonalUseCase.swift in Sources */,
 				DE93B6FF2ED06B9B00BCFB5D /* CommunityDiaryPreview.swift in Sources */,
 				70A97C602E2164C600F08DF6 /* HomePresentationAssembly.swift in Sources */,

--- a/GraceLog.xcodeproj/project.pbxproj
+++ b/GraceLog.xcodeproj/project.pbxproj
@@ -173,6 +173,8 @@
 		DE6459B32F10CBC700C98B5A /* NotificationCenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6459B22F10CBC700C98B5A /* NotificationCenterManager.swift */; };
 		DE645A452F1A44F300C98B5A /* ProfileEditPresentationAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645A442F1A44F300C98B5A /* ProfileEditPresentationAssembly.swift */; };
 		DE645A472F1B696800C98B5A /* AnnouncementPresentationAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645A462F1B696800C98B5A /* AnnouncementPresentationAssembly.swift */; };
+		DE645B872F1FA44800C98B5A /* CreateCommunityRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645B862F1FA44800C98B5A /* CreateCommunityRequestDTO.swift */; };
+		DE645B8A2F20462500C98B5A /* CreateCommunityPresentationAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE645B892F20462500C98B5A /* CreateCommunityPresentationAssembly.swift */; };
 		DE655B1F2DA1758F0073B4F7 /* CommonDivideTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE655B1E2DA1758F0073B4F7 /* CommonDivideTableViewCell.swift */; };
 		DE655B212DA5EC480073B4F7 /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE655B202DA5EC480073B4F7 /* UILabel+Extension.swift */; };
 		DE66C2F32D941AF5009A983F /* DiaryShareTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE66C2F22D941AF5009A983F /* DiaryShareTableViewCell.swift */; };
@@ -454,6 +456,8 @@
 		DE6459B22F10CBC700C98B5A /* NotificationCenterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterManager.swift; sourceTree = "<group>"; };
 		DE645A442F1A44F300C98B5A /* ProfileEditPresentationAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditPresentationAssembly.swift; sourceTree = "<group>"; };
 		DE645A462F1B696800C98B5A /* AnnouncementPresentationAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementPresentationAssembly.swift; sourceTree = "<group>"; };
+		DE645B862F1FA44800C98B5A /* CreateCommunityRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCommunityRequestDTO.swift; sourceTree = "<group>"; };
+		DE645B892F20462500C98B5A /* CreateCommunityPresentationAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCommunityPresentationAssembly.swift; sourceTree = "<group>"; };
 		DE655B1E2DA1758F0073B4F7 /* CommonDivideTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonDivideTableViewCell.swift; sourceTree = "<group>"; };
 		DE655B202DA5EC480073B4F7 /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		DE66C2F22D941AF5009A983F /* DiaryShareTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryShareTableViewCell.swift; sourceTree = "<group>"; };
@@ -859,9 +863,10 @@
 			isa = PBXGroup;
 			children = (
 				DE597A6C2E26140300B2CB5B /* Auth */,
+				70A97C5E2E21646000F08DF6 /* Home */,
 				70A97C642E2169C700F08DF6 /* MyInfo */,
 				70A97C612E2167B400F08DF6 /* Diary */,
-				70A97C5E2E21646000F08DF6 /* Home */,
+				DE645B882F2045F800C98B5A /* Community */,
 			);
 			path = PresentationDI;
 			sourceTree = "<group>";
@@ -1512,6 +1517,14 @@
 			path = NotificationCenter;
 			sourceTree = "<group>";
 		};
+		DE645B882F2045F800C98B5A /* Community */ = {
+			isa = PBXGroup;
+			children = (
+				DE645B892F20462500C98B5A /* CreateCommunityPresentationAssembly.swift */,
+			);
+			path = Community;
+			sourceTree = "<group>";
+		};
 		DE66C2F82D96B380009A983F /* Diary */ = {
 			isa = PBXGroup;
 			children = (
@@ -1599,6 +1612,7 @@
 				DE4237572EBF07AF006FAA7B /* LikeDiaryRequestDTO.swift */,
 				DE4237592EC20AB8006FAA7B /* LikeCountRequestDTO.swift */,
 				DE93B6F42ECDF6C000BCFB5D /* CommunityDiaryListRequestDTO.swift */,
+				DE645B862F1FA44800C98B5A /* CreateCommunityRequestDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -2092,6 +2106,7 @@
 				709CBB5B2E2AACB600F68457 /* DefaultCommentUseCase.swift in Sources */,
 				709CBB672E2AC8E900F68457 /* CommentTableViewCell.swift in Sources */,
 				DE4237462EBCC96B006FAA7B /* CreateDiaryRequestDTO.swift in Sources */,
+				DE645B872F1FA44800C98B5A /* CreateCommunityRequestDTO.swift in Sources */,
 				DEA80D962F0504F100216B1D /* DefaultVideoRepository.swift in Sources */,
 				70062C562E4AF8FA0096C1F7 /* URL+Extension.swift in Sources */,
 				DE6459B12F10CBB800C98B5A /* NotificationCenterHandler.swift in Sources */,
@@ -2118,6 +2133,7 @@
 				DE4237502EBEE935006FAA7B /* DefaultDiaryRepository.swift in Sources */,
 				DE66C2F52D96B0E4009A983F /* DiaryViewReactor.swift in Sources */,
 				DE66C2F32D941AF5009A983F /* DiaryShareTableViewCell.swift in Sources */,
+				DE645B8A2F20462500C98B5A /* CreateCommunityPresentationAssembly.swift in Sources */,
 				DE66C2F32D941AF5009A983F /* DiaryShareTableViewCell.swift in Sources */,
 				DEA80D9E2F050B3F00216B1D /* DefaultDailyVerseRepository.swift in Sources */,
 				DEACFE6A2E0F81DE00AD4222 /* HomeCommunityListSection.swift in Sources */,

--- a/GraceLog.xcodeproj/project.pbxproj
+++ b/GraceLog.xcodeproj/project.pbxproj
@@ -559,6 +559,11 @@
 			path = Constants;
 			sourceTree = "<group>";
 		};
+		70D73E8F2F06ACA00045D531 /* DataSource */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = DataSource;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1328,6 +1333,7 @@
 		DE3BFCC62D043DB70076426D /* SearchScene */ = {
 			isa = PBXGroup;
 			children = (
+				70D73E8F2F06ACA00045D531 /* DataSource */,
 				70CBC75E2E925FEF0037C613 /* Reactor */,
 				70CBC75C2E925FCB0037C613 /* View */,
 				DE3BFCE22D059DEF0076426D /* Coordinator */,
@@ -1675,6 +1681,7 @@
 				70CBC75C2E925FCB0037C613 /* View */,
 				70CBC75E2E925FEF0037C613 /* Reactor */,
 				70D053A82EB772CF00060BE5 /* Constants */,
+				70D73E8F2F06ACA00045D531 /* DataSource */,
 			);
 			name = GraceLog;
 			productName = GraceLog;

--- a/GraceLog.xcodeproj/project.pbxproj
+++ b/GraceLog.xcodeproj/project.pbxproj
@@ -527,6 +527,11 @@
 			path = Constants;
 			sourceTree = "<group>";
 		};
+		70D73E8F2F06ACA00045D531 /* DataSource */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = DataSource;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1284,6 +1289,7 @@
 		DE3BFCC62D043DB70076426D /* SearchScene */ = {
 			isa = PBXGroup;
 			children = (
+				70D73E8F2F06ACA00045D531 /* DataSource */,
 				70CBC75E2E925FEF0037C613 /* Reactor */,
 				70CBC75C2E925FCB0037C613 /* View */,
 				DE3BFCE22D059DEF0076426D /* Coordinator */,
@@ -1623,6 +1629,7 @@
 				70CBC75C2E925FCB0037C613 /* View */,
 				70CBC75E2E925FEF0037C613 /* Reactor */,
 				70D053A82EB772CF00060BE5 /* Constants */,
+				70D73E8F2F06ACA00045D531 /* DataSource */,
 			);
 			name = GraceLog;
 			productName = GraceLog;

--- a/GraceLog/Source/Application/DIContainer/DomainAssembly.swift
+++ b/GraceLog/Source/Application/DIContainer/DomainAssembly.swift
@@ -58,7 +58,7 @@ struct DomainAssembly: Assembly {
         }
         
         // DiaryDetails
-        container.register(DiaryDetailsUseCase.self) { (resolver, diaryId: Int) in
+        container.register(DiaryDetailsUseCase.self) { (resolver, communityId: Int, memberId: Int) in
             let diaryRepository = resolver.resolve(DiaryRepository.self)!
             let likeRepository = resolver.resolve(LikeRepository.self)!
             

--- a/GraceLog/Source/Application/DIContainer/DomainAssembly.swift
+++ b/GraceLog/Source/Application/DIContainer/DomainAssembly.swift
@@ -39,11 +39,12 @@ struct DomainAssembly: Assembly {
         }
         
         // DiaryDetails
-        container.register(DiaryDetailsUseCase.self) { (resolver, diaryId: Int) in
+        container.register(DiaryDetailsUseCase.self) { (resolver, communityId: Int, memberId: Int) in
             let diaryRepository = resolver.resolve(DiaryRepository.self)!
             return DefaultDiaryDetailsUseCase(
                 diaryRepository: diaryRepository,
-                diaryId: diaryId
+                communityId: communityId,
+                memberId: memberId
             )
         }
         

--- a/GraceLog/Source/Application/DIContainer/DomainAssembly.swift
+++ b/GraceLog/Source/Application/DIContainer/DomainAssembly.swift
@@ -58,14 +58,16 @@ struct DomainAssembly: Assembly {
         }
         
         // DiaryDetails
-        container.register(DiaryDetailsUseCase.self) { (resolver, diaryId: Int) in
+        container.register(DiaryDetailsUseCase.self) { (resolver, diaryId: Int, communityId: Int?, memberId: Int?) in
             let diaryRepository = resolver.resolve(DiaryRepository.self)!
             let likeRepository = resolver.resolve(LikeRepository.self)!
             
             return DefaultDiaryDetailsUseCase(
                 diaryRepository: diaryRepository,
                 likeRepository: likeRepository,
-                diaryId: diaryId
+                diaryId: diaryId,
+                communityId: communityId,
+                memberId: memberId
             )
         }
         

--- a/GraceLog/Source/Application/DIContainer/DomainAssembly.swift
+++ b/GraceLog/Source/Application/DIContainer/DomainAssembly.swift
@@ -58,7 +58,7 @@ struct DomainAssembly: Assembly {
         }
         
         // DiaryDetails
-        container.register(DiaryDetailsUseCase.self) { (resolver, communityId: Int, memberId: Int) in
+        container.register(DiaryDetailsUseCase.self) { (resolver, diaryId: Int) in
             let diaryRepository = resolver.resolve(DiaryRepository.self)!
             let likeRepository = resolver.resolve(LikeRepository.self)!
             
@@ -81,6 +81,12 @@ struct DomainAssembly: Assembly {
         
         container.register(AnnouncementDetailUseCase.self) { resolver, announcementId in
             return DefaultAnnouncementDetailUseCase(announcementId: announcementId)
+        }
+        
+        // Community
+        container.register(CreateCommunityUseCase.self) { resolver in
+            let communityRepository = resolver.resolve(CommunityRepository.self)!
+            return DefaultCreateCommunityUseCase(communityRepository: communityRepository)
         }
     }
 }

--- a/GraceLog/Source/Application/DIContainer/DomainAssembly.swift
+++ b/GraceLog/Source/Application/DIContainer/DomainAssembly.swift
@@ -90,5 +90,16 @@ struct DomainAssembly: Assembly {
             let communityRepository = resolver.resolve(CommunityRepository.self)!
             return DefaultCreateCommunityUseCase(communityRepository: communityRepository)
         }
+        
+        container.register(CommunityGroupUseCase.self) { (resolver, communityId: Int) in
+            let diaryRepository = resolver.resolve(DiaryRepository.self)!
+            let likeRepository = resolver.resolve(LikeRepository.self)!
+            
+            return DefaultCommunityGroupUseCase(
+                diaryRepository: diaryRepository,
+                likeRepository: likeRepository,
+                communityId: communityId
+            )
+        }
     }
 }

--- a/GraceLog/Source/Application/DIContainer/PresentationDI/Community/CommunityGroupPresentationAssembly.swift
+++ b/GraceLog/Source/Application/DIContainer/PresentationDI/Community/CommunityGroupPresentationAssembly.swift
@@ -1,0 +1,22 @@
+//
+//  CommunityGroupPresentationAssembly.swift
+//  GraceLog
+//
+//  Created by 이상준 on 2/3/26.
+//
+
+import Swinject
+
+struct CommunityGroupPresentationAssembly: Assembly {
+    func assemble(container: Container) {
+        container.register(CommunityGroupReactor.self) { (resolver, communityId: Int) in
+            let usecase = resolver.resolve(CommunityGroupUseCase.self, argument: communityId)!
+            return CommunityGroupReactor(usecase: usecase)
+        }
+        
+        container.register(CommunityGroupViewController.self) { (resolver, communityId: Int) in
+            let reactor = resolver.resolve(CommunityGroupReactor.self, argument: communityId)!
+            return CommunityGroupViewController(reactor: reactor)
+        }
+    }
+}

--- a/GraceLog/Source/Application/DIContainer/PresentationDI/Community/CreateCommunityPresentationAssembly.swift
+++ b/GraceLog/Source/Application/DIContainer/PresentationDI/Community/CreateCommunityPresentationAssembly.swift
@@ -1,0 +1,22 @@
+//
+//  CreateCommunityPresentationAssembly.swift
+//  GraceLog
+//
+//  Created by 이상준 on 1/21/26.
+//
+
+import Swinject
+
+struct CreateCommunityPresentationAssembly: Assembly {
+    func assemble(container: Container) {
+        container.register(CreateCommunityReactor.self) { resolver in
+            let usecase = resolver.resolve(CreateCommunityUseCase.self)!
+            return CreateCommunityReactor(usecase: usecase)
+        }
+        
+        container.register(CreateCommunityViewController.self) { resolver in
+            let reactor = resolver.resolve(CreateCommunityReactor.self)!
+            return CreateCommunityViewController(reactor: reactor)
+        }
+    }
+}

--- a/GraceLog/Source/Application/DIContainer/PresentationDI/Diary/DiaryDetailsPresentationAssembly.swift
+++ b/GraceLog/Source/Application/DIContainer/PresentationDI/Diary/DiaryDetailsPresentationAssembly.swift
@@ -9,19 +9,33 @@ import Swinject
 
 struct DiaryDetailsPresentationAssembly: Assembly {
     func assemble(container: Container) {
-        container.register(DiaryDetailsViewReactor.self) { (resolver, coordinator: DiaryDetailsCoordinator, diaryId: Int) in
-            let usecase = resolver.resolve(DiaryDetailsUseCase.self, argument: diaryId)!
+        container.register(DiaryDetailsViewReactor.self) { (
+            resolver,
+            coordinator: DiaryDetailsCoordinator,
+            diaryId: Int,
+            communityId: Int?,
+            memberId: Int?
+        ) in
+            let usecase = resolver.resolve(
+                DiaryDetailsUseCase.self,
+                arguments: diaryId, communityId, memberId
+            )!
             return DiaryDetailsViewReactor(
                 coordinator: coordinator,
                 usecase: usecase
             )
         }
         
-        container.register(DiaryDetailsViewController.self) { (resolver, coordinator: DiaryDetailsCoordinator, diaryId: Int) in
+        container.register(DiaryDetailsViewController.self) { (
+            resolver,
+            coordinator: DiaryDetailsCoordinator,
+            diaryId: Int,
+            communityId: Int?,
+            memberId: Int?
+        ) in
             let reactor = resolver.resolve(
                 DiaryDetailsViewReactor.self,
-                arguments: coordinator,
-                diaryId
+                arguments: coordinator, diaryId, communityId, memberId
             )!
             return DiaryDetailsViewController(reactor: reactor)
         }

--- a/GraceLog/Source/Application/GraceLogAppCoordinator.swift
+++ b/GraceLog/Source/Application/GraceLogAppCoordinator.swift
@@ -6,11 +6,14 @@
 //
 
 import UIKit
+import RxSwift
 
 final class GraceLogAppCoordinator: NavigationCoordinator {
     var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
+    
+    private let disposeBag = DisposeBag()
     
     private var isLoggedIn: Bool {
         TokenManager.shared.isLoggedIn()
@@ -18,14 +21,22 @@ final class GraceLogAppCoordinator: NavigationCoordinator {
     
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController
+        
+        NotificationCenter.default.rx
+            .notification(NotificationCenterManager.authenticationDidFail.name)
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, _ in
+                owner.handleAuthenticationFailure()
+            }
+            .disposed(by: disposeBag)
     }
     
     func start() {
-//        showMainTabFlow()
         isLoggedIn ? showMainTabFlow() : showLoginFlow()
     }
     
     @objc private func handleAuthenticationFailure() {
+        childCoordinators.removeAll()
         showLoginFlow()
     }
     

--- a/GraceLog/Source/Data/Network/API/CommunityAPI.swift
+++ b/GraceLog/Source/Data/Network/API/CommunityAPI.swift
@@ -9,6 +9,7 @@ import Alamofire
 
 enum CommunityAPI {
     case fetchMyCommunityList
+    case createCommunity(CreateCommunityRequestDTO)
     case joinCommunity(communityId: Int)
     case leaveCommunity(communityId: Int)
 }
@@ -21,6 +22,7 @@ extension CommunityAPI: TargetType {
     var method: HTTPMethod {
         switch self {
         case .fetchMyCommunityList: return .get
+        case .createCommunity: return .post
         case .joinCommunity: return .post
         case .leaveCommunity: return .delete
         }
@@ -28,7 +30,7 @@ extension CommunityAPI: TargetType {
     
     var path: String {
         switch self {
-        case .fetchMyCommunityList:
+        case .fetchMyCommunityList, .createCommunity:
             return "/community"
         case .joinCommunity(let id):
             return "/community/\(id)/join"
@@ -39,13 +41,15 @@ extension CommunityAPI: TargetType {
     
     var headers: HeaderType {
         switch self {
-        case .fetchMyCommunityList, .joinCommunity, .leaveCommunity:
+        case .fetchMyCommunityList, .createCommunity, .joinCommunity, .leaveCommunity:
             return .requireAccessToken
         }
     }
     
     var parameters: RequestParams {
         switch self {
+        case .createCommunity(let request):
+            return .body(request)
         case .fetchMyCommunityList, .joinCommunity, .leaveCommunity:
             return .none
         }

--- a/GraceLog/Source/Data/Network/API/DiaryAPI.swift
+++ b/GraceLog/Source/Data/Network/API/DiaryAPI.swift
@@ -11,8 +11,11 @@ enum DiaryAPI {
     case createDiary(CreateDiaryRequestDTO)
     case fetchDiary(diaryId: Int)
     case fetchCommunityDiaryList(CommunityDiaryListRequestDTO)
+    case fetchMyActivityDiaryList(MyActivityDiaryListRequestDTO)
     case fetchMyDiaryList(MyDiaryListRequestDTO)
     case fetchDateRangeDiaryList(DateRangeDiaryListRequestDTO)
+    case fetchLastPostDate(DiaryLastPostDateRequestDTO)
+    case fetchDiaryExistenceDates(DiaryExistenceDatesRequestDTO)
     case deleteDiary(diaryId: Int)
 }
 
@@ -26,8 +29,11 @@ extension DiaryAPI: TargetType {
         case .createDiary: return .post
         case .fetchDiary: return .get
         case .fetchCommunityDiaryList: return .get
+        case .fetchMyActivityDiaryList: return .get
         case .fetchMyDiaryList: return .get
         case .fetchDateRangeDiaryList: return .get
+        case .fetchLastPostDate: return .get
+        case .fetchDiaryExistenceDates: return .get
         case .deleteDiary: return .delete
         }
     }
@@ -38,10 +44,16 @@ extension DiaryAPI: TargetType {
             return ""
         case .fetchDiary(let id):
             return "/\(id)"
+        case .fetchMyActivityDiaryList:
+            return "/myActivity"
         case .fetchMyDiaryList:
             return "/myPostList"
         case .fetchDateRangeDiaryList:
             return "/dateRangePostList"
+        case .fetchLastPostDate:
+            return "/lastPostDate"
+        case .fetchDiaryExistenceDates:
+            return "/dateRangePostExistence"
         case .deleteDiary(let id):
             return "/\(id)"
         }
@@ -64,9 +76,15 @@ extension DiaryAPI: TargetType {
             return .none
         case .fetchCommunityDiaryList(let params):
             return .query(params)
+        case .fetchMyActivityDiaryList(let params):
+            return .query(params)
         case .fetchMyDiaryList(let params):
             return .query(params)
         case .fetchDateRangeDiaryList(let params):
+            return .query(params)
+        case .fetchLastPostDate(let params):
+            return .query(params)
+        case .fetchDiaryExistenceDates(let params):
             return .query(params)
         case .deleteDiary:
             return .none

--- a/GraceLog/Source/Data/Network/Bases/GLInterceptor.swift
+++ b/GraceLog/Source/Data/Network/Bases/GLInterceptor.swift
@@ -11,34 +11,64 @@ import Alamofire
 import RxSwift
 import CryptoKit
 
-final class GLInterceptor: RequestInterceptor {
+final class GLInterceptor: RequestInterceptor, @unchecked Sendable {
     private let disposeBag = DisposeBag()
     
+    private let retryLimit = 3
+    private let lock = NSLock()
+    private var isRefreshing = false
+    private var requestsForRetry: [(RetryResult) -> Void] = []
+    
     func retry(_ request: Request, for session: Session, dueTo error: any Error, completion: @escaping (RetryResult) -> Void) {
-        guard let statusCode = request.response?.statusCode,
-              !(200..<300).contains(statusCode)
-        else {
-            completion(.doNotRetry)
+        lock.lock()
+        defer { lock.unlock() }
+        
+        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401 else {
+            completion(.doNotRetryWithError(error))
             return
         }
         
-        guard statusCode == 401 else {
-            completion(.doNotRetryWithError(error))
-            return
-          }
+        guard request.retryCount < retryLimit else { return completion(.doNotRetryWithError(error)) }
+        
+        requestsForRetry.append(completion)
         
         guard let refreshToken = TokenManager.shared.refreshToken else { return }
         let request = RefreshTokenRequestDTO(refreshToken: refreshToken)
-        NetworkManager()
-            .request(AuthAPI.refresh(request))
-            .subscribe(onSuccess: { (result: SignInResponseDTO) in
-                TokenManager.shared.accessToken = result.accessToken
-                TokenManager.shared.refreshToken = result.refreshToken
-                
-                completion(.retry)
-            }, onFailure: { error in
-                completion(.doNotRetryWithError(error))
-            })
-            .disposed(by: disposeBag)
+        
+        if !isRefreshing {
+            isRefreshing = true
+            
+            NetworkManager()
+                .request(AuthAPI.refresh(request))
+                .subscribe(onSuccess: { (result: SignInResponseDTO) in
+                    self.lock.lock()
+                    defer {
+                        self.lock.unlock()
+                        self.isRefreshing = false
+                        self.requestsForRetry.removeAll()
+                    }
+                    
+                    TokenManager.shared.accessToken = result.accessToken
+                    TokenManager.shared.refreshToken = result.refreshToken
+                    
+                    completion(.retry)
+                }, onFailure: { error in
+                    self.lock.lock()
+                    defer {
+                        self.lock.unlock()
+                        self.isRefreshing = false
+                        self.requestsForRetry.removeAll()
+                    }
+                    
+                    self.handleAuthenticationFailure()
+                    completion(.doNotRetryWithError(error))
+                })
+                .disposed(by: disposeBag)
+        }
+    }
+    
+    private func handleAuthenticationFailure() {
+        TokenManager.shared.clearTokens()
+        NotificationCenterManager.authenticationDidFail.post()
     }
 }

--- a/GraceLog/Source/Data/Network/DTO/Request/CreateCommunityRequestDTO.swift
+++ b/GraceLog/Source/Data/Network/DTO/Request/CreateCommunityRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  CreateCommunityRequestDTO.swift
+//  GraceLog
+//
+//  Created by 이상준 on 1/20/26.
+//
+
+import Foundation
+
+struct CreateCommunityRequestDTO: Encodable {
+    let name: String
+}

--- a/GraceLog/Source/Data/Network/DTO/Request/DiaryExistenceDatesRequestDTO.swift
+++ b/GraceLog/Source/Data/Network/DTO/Request/DiaryExistenceDatesRequestDTO.swift
@@ -1,13 +1,13 @@
 //
-//  ComunityDiaryListRequestDTO.swift
+//  DiaryExistenceDatesRequestDTO.swift
 //  GraceLog
 //
-//  Created by 이상준 on 11/6/25.
+//  Created by 이상준 on 1/30/26.
 //
 
 import Foundation
 
-struct DateRangeDiaryListRequestDTO: Encodable {
+struct DiaryExistenceDatesRequestDTO: Encodable {
     let startDate: String
     let endDate: String
     let communityId: Int?

--- a/GraceLog/Source/Data/Network/DTO/Request/DiaryLastPostDateRequestDTO.swift
+++ b/GraceLog/Source/Data/Network/DTO/Request/DiaryLastPostDateRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  DiaryLastPostDateRequestDTO.swift
+//  GraceLog
+//
+//  Created by 이상준 on 2/3/26.
+//
+
+import Foundation
+
+struct DiaryLastPostDateRequestDTO: Encodable {
+    let communityId: Int
+}

--- a/GraceLog/Source/Data/Network/DTO/Request/MyActivityDiaryListRequestDTO.swift
+++ b/GraceLog/Source/Data/Network/DTO/Request/MyActivityDiaryListRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  MyActivityDiaryListRequestDTO.swift
+//  GraceLog
+//
+//  Created by 이상준 on 1/30/26.
+//
+
+import Foundation
+
+struct MyActivityDiaryListRequestDTO: Encodable {
+    let cursorId: Int
+    let size: Int
+}

--- a/GraceLog/Source/Data/Network/DTO/Response/DiaryExistenceDateResponseDTO.swift
+++ b/GraceLog/Source/Data/Network/DTO/Response/DiaryExistenceDateResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  DiaryExistenceDatesResponseDTO.swift
+//  GraceLog
+//
+//  Created by 이상준 on 1/31/26.
+//
+
+import Foundation
+
+struct DiaryExistenceDateResponseDTO: Decodable {
+    let date: String
+    let isExistPost: Bool
+}

--- a/GraceLog/Source/Data/Network/DTO/Response/DiaryLastPostDateResponseDTO.swift
+++ b/GraceLog/Source/Data/Network/DTO/Response/DiaryLastPostDateResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  DiaryLastPostDateResponseDTO.swift
+//  GraceLog
+//
+//  Created by 이상준 on 2/3/26.
+//
+
+import Foundation
+
+struct DiaryLastPostDateResponseDTO: Decodable {
+    let lastPostDate: String
+}

--- a/GraceLog/Source/Data/Repository/DefaultCommunityRepository.swift
+++ b/GraceLog/Source/Data/Repository/DefaultCommunityRepository.swift
@@ -28,4 +28,15 @@ final class DefaultCommunityRepository: CommunityRepository {
                 }
             }
     }
+    
+    func createCommunity(images: [Data], name: String) -> Single<GLEmptyResponse> {
+        let request = CreateCommunityRequestDTO(name: name)
+        
+        return network.request(
+            CommunityAPI.createCommunity(request),
+            images: images,
+            bodyFieldName: "createCommunityRequest",
+            imageFieldName: "communityImage"
+        )
+    }
 }

--- a/GraceLog/Source/Data/Repository/DefaultDiaryRepository.swift
+++ b/GraceLog/Source/Data/Repository/DefaultDiaryRepository.swift
@@ -51,6 +51,7 @@ final class DefaultDiaryRepository: DiaryRepository {
                 return responseDTO.map { diaryResponseDTO in
                     return MyDiaryPreview(
                         id: diaryResponseDTO.postId,
+                        userId: diaryResponseDTO.member.memberId,
                         editedDate: DateFormatterFactory.dateTimeWithISO.date(from: diaryResponseDTO.updatedAt),
                         title: diaryResponseDTO.title,
                         content: diaryResponseDTO.description,
@@ -61,8 +62,15 @@ final class DefaultDiaryRepository: DiaryRepository {
     }
     
     
-    func fetchDateRangeDiaryList(startDate: String, endDate: String, communityId: Int?, memberId: Int) -> Single<[DiaryDetails]> {
-        let request = DateRangeDiaryListRequestDTO(startDate: startDate, endDate: endDate, communityId: communityId, memberId: memberId)
+    func fetchDateRangeDiaryList(startDate: String, endDate: String, communityId: Int?, memberId: Int, cursorId: Int?, size: Int?) -> Single<[DiaryDetails]> {
+        let request = DateRangeDiaryListRequestDTO(
+            startDate: startDate,
+            endDate: endDate,
+            communityId: communityId,
+            memberId: memberId,
+            cursorId: nil,
+            size: nil
+        )
         
         return network.request(DiaryAPI.fetchDateRangeDiaryList(request))
             .map { (responseDTO: [DiaryResponseDTO]) in
@@ -110,10 +118,12 @@ final class DefaultDiaryRepository: DiaryRepository {
                         isLiked: diaryResponseDTO.likedByMe,
                         likeCount: diaryResponseDTO.likeCount,
                         commentCount: diaryResponseDTO.commentCount,
+                        userId: diaryResponseDTO.member.memberId,
                         username: diaryResponseDTO.member.name,
                         profileImageURL: diaryResponseDTO.member.profileImage,
                         diaryImageURL: diaryResponseDTO.postImages.first?.url,
-                        isCurrentUser: UserManager.shared.id == diaryResponseDTO.member.memberId
+                        isCurrentUser: UserManager.shared.id == diaryResponseDTO.member.memberId,
+                        communityId: diaryResponseDTO.postCommunityId
                     )
                 }
                 
@@ -121,6 +131,144 @@ final class DefaultDiaryRepository: DiaryRepository {
                     diaryList: diaryList,
                     isLastPage: responseDTO.last
                 )
+            }
+    }
+    
+    func fetchDateRangeMemberDiaryList(startDate: String, endDate: String, memberId: Int, communityId: Int?, cursorId: Int?, size: Int?) -> Single<[DiaryDetails]> {
+        let request = DateRangeDiaryListRequestDTO(
+            startDate: startDate,
+            endDate: endDate,
+            communityId: communityId,
+            memberId: memberId,
+            cursorId: cursorId,
+            size: size
+        )
+        
+        return network.request(DiaryAPI.fetchDateRangeDiaryList(request))
+            .map { (responseDTO: DiaryPagingResponseDTO) in
+                return responseDTO.content.map { diaryResponseDTO in
+                    return DiaryDetails(
+                        diaryId: diaryResponseDTO.postId,
+                        communityId: diaryResponseDTO.postCommunityId,
+                        title: diaryResponseDTO.title,
+                        description: diaryResponseDTO.description,
+                        user: GraceLogUser(
+                            id: diaryResponseDTO.member.memberId,
+                            name: diaryResponseDTO.member.name,
+                            nickname: diaryResponseDTO.member.nickname,
+                            profileImageURL: diaryResponseDTO.member.profileImage,
+                            email: diaryResponseDTO.member.email,
+                            message: diaryResponseDTO.member.message
+                        ),
+                        imageURLs: diaryResponseDTO.postImages.map { $0.url },
+                        likeCount: diaryResponseDTO.likeCount,
+                        likeByMe: diaryResponseDTO.likedByMe,
+                        isHideLike: diaryResponseDTO.isHideLike,
+                        isHideComment: diaryResponseDTO.isHideComment,
+                        commentCount: diaryResponseDTO.commentCount,
+                        createdAt: DateFormatterFactory.dateTimeWithISO.date(from: diaryResponseDTO.createdAt)
+                    )
+                }
+            }
+    }
+    
+    func fetchDateRangeCommunityDiaryList(startDate: String, endDate: String, communityId: Int, memberId: Int?, cursorId: Int?, size: Int) -> Single<CommunityDiaryPreViewInfo> {
+        
+        let request = DateRangeDiaryListRequestDTO(
+            startDate: startDate,
+            endDate: endDate,
+            communityId: communityId,
+            memberId: memberId,
+            cursorId: cursorId,
+            size: size
+        )
+        
+        return network.request(DiaryAPI.fetchDateRangeDiaryList(request))
+            .map { (responseDTO: DiaryPagingResponseDTO) in
+                let diaryList = responseDTO.content.map { diaryResponseDTO in
+                    return CommunityDiaryPreview(
+                        id: diaryResponseDTO.postId,
+                        title: diaryResponseDTO.title,
+                        content: diaryResponseDTO.description,
+                        editedDate: DateFormatterFactory.dateTimeWithISO.date(from: diaryResponseDTO.updatedAt),
+                        isLiked: diaryResponseDTO.likedByMe,
+                        likeCount: diaryResponseDTO.likeCount,
+                        commentCount: diaryResponseDTO.commentCount,
+                        userId: diaryResponseDTO.member.memberId,
+                        username: diaryResponseDTO.member.name,
+                        profileImageURL: diaryResponseDTO.member.profileImage,
+                        diaryImageURL: diaryResponseDTO.postImages.first?.url,
+                        isCurrentUser: UserManager.shared.id == diaryResponseDTO.member.memberId,
+                        communityId: diaryResponseDTO.postCommunityId
+                    )
+                }
+                
+                return CommunityDiaryPreViewInfo(
+                    diaryList: diaryList,
+                    isLastPage: responseDTO.last
+                )
+            }
+    }
+    
+    func fetchMyActivityDiaryList(cursorId: Int, size: Int) -> Single<CommunityDiaryPreViewInfo> {
+        let request = MyActivityDiaryListRequestDTO(cursorId: cursorId, size: size)
+        
+        return network.request(DiaryAPI.fetchMyActivityDiaryList(request))
+            .map { (responseDTO: DiaryPagingResponseDTO) in
+                let diaryList = responseDTO.content.map { diaryResponseDTO in
+                    return CommunityDiaryPreview(
+                        id: diaryResponseDTO.postId,
+                        title: diaryResponseDTO.title,
+                        content: diaryResponseDTO.description,
+                        editedDate: DateFormatterFactory.dateTimeWithISO.date(from: diaryResponseDTO.updatedAt),
+                        isLiked: diaryResponseDTO.likedByMe,
+                        likeCount: diaryResponseDTO.likeCount,
+                        commentCount: diaryResponseDTO.commentCount,
+                        userId: diaryResponseDTO.member.memberId,
+                        username: diaryResponseDTO.member.name,
+                        profileImageURL: diaryResponseDTO.member.profileImage,
+                        diaryImageURL: diaryResponseDTO.postImages.first?.url,
+                        isCurrentUser: UserManager.shared.id == diaryResponseDTO.member.memberId,
+                        communityId: diaryResponseDTO.postCommunityId
+                    )
+                }
+                
+                return CommunityDiaryPreViewInfo(
+                    diaryList: diaryList,
+                    isLastPage: responseDTO.last
+                )
+            }
+    }
+    
+    func fetchDiaryLastPostDate(communityId: Int) -> Single<Date?> {
+        let request = DiaryLastPostDateRequestDTO(communityId: communityId)
+        return network.request(DiaryAPI.fetchLastPostDate(request))
+            .map { (responseDTO: DiaryLastPostDateResponseDTO) in
+                let date = responseDTO.lastPostDate.toDate()
+                return date
+            }
+    }
+    
+    func fetchDiaryExistenceDates(startDate: String, endDate: String, communityId: Int?, memberId: Int?, cursorId: Int?, size: Int?) -> Single<[DiaryExistenceDate]> {
+        let request = DiaryExistenceDatesRequestDTO(
+            startDate: startDate,
+            endDate: endDate,
+            communityId: communityId,
+            memberId: memberId,
+            cursorId: cursorId,
+            size: size
+        )
+        
+        return network.request(DiaryAPI.fetchDiaryExistenceDates(request))
+            .map { (responseDTO: [DiaryExistenceDateResponseDTO]) in
+                return responseDTO
+                    .filter { $0.isExistPost }
+                    .compactMap { dateResponseDTO in
+                        guard let date = dateResponseDTO.date.toDate() else {
+                            return nil
+                        }
+                        return DiaryExistenceDate(date: date)
+                    }
             }
     }
     

--- a/GraceLog/Source/Domain/Entity/CommunityDiaryPreview.swift
+++ b/GraceLog/Source/Domain/Entity/CommunityDiaryPreview.swift
@@ -20,8 +20,10 @@ struct CommunityDiaryPreview {
     var isLiked: Bool
     var likeCount: Int
     let commentCount: Int
+    let userId: Int
     let username: String
     let profileImageURL: URL?
     let diaryImageURL: URL?
     let isCurrentUser: Bool
+    let communityId: Int?
 }

--- a/GraceLog/Source/Domain/Entity/DiaryExistenceDate.swift
+++ b/GraceLog/Source/Domain/Entity/DiaryExistenceDate.swift
@@ -1,0 +1,12 @@
+//
+//  DiaryExistenceDate.swift
+//  GraceLog
+//
+//  Created by 이상준 on 1/31/26.
+//
+
+import Foundation
+
+struct DiaryExistenceDate {
+    let date: Date
+}

--- a/GraceLog/Source/Domain/Entity/MyDiaryPreview.swift
+++ b/GraceLog/Source/Domain/Entity/MyDiaryPreview.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct MyDiaryPreview {
     let id: Int
+    let userId: Int
     let editedDate: Date?
     let title: String
     let content: String
@@ -19,6 +20,7 @@ extension MyDiaryPreview {
     static var empty: MyDiaryPreview {
         MyDiaryPreview(
             id: 0,
+            userId: 0,
             editedDate: nil,
             title: "",
             content: "",

--- a/GraceLog/Source/Domain/Protocol/CommunityRepository.swift
+++ b/GraceLog/Source/Domain/Protocol/CommunityRepository.swift
@@ -10,4 +10,5 @@ import RxSwift
 
 protocol CommunityRepository {
     func fetchMyCommunityList() -> Single<[Community]>
+    func createCommunity(images: [Data], name: String) -> Single<GLEmptyResponse> 
 }

--- a/GraceLog/Source/Domain/Protocol/DiaryRepository.swift
+++ b/GraceLog/Source/Domain/Protocol/DiaryRepository.swift
@@ -17,11 +17,31 @@ protocol DiaryRepository {
         startDate: String,
         endDate: String,
         communityId: Int?,
-        memberId: Int
+        memberId: Int,
+        cursorId: Int?,
+        size: Int?
     ) -> Single<[DiaryDetails]>
     
     func fetchCommunityDiaryList(
         communityId: Int,
+        cursorId: Int?,
+        size: Int
+    ) -> Single<CommunityDiaryPreViewInfo>
+    
+    func fetchDateRangeMemberDiaryList(
+        startDate: String,
+        endDate: String,
+        memberId: Int,
+        communityId: Int?,
+        cursorId: Int?,
+        size: Int?
+    ) -> Single<[DiaryDetails]>
+    
+    func fetchDateRangeCommunityDiaryList(
+        startDate: String,
+        endDate: String,
+        communityId: Int,
+        memberId: Int?,
         cursorId: Int?,
         size: Int
     ) -> Single<CommunityDiaryPreViewInfo>
@@ -36,6 +56,24 @@ protocol DiaryRepository {
         isHideLike: Bool,
         isHideComment: Bool
     ) -> Single<GLEmptyResponse>
+    
+    func fetchMyActivityDiaryList(
+        cursorId: Int,
+        size: Int
+    ) -> Single<CommunityDiaryPreViewInfo>
+    
+    func fetchDiaryLastPostDate(
+        communityId: Int
+    ) -> Single<Date?>
+    
+    func fetchDiaryExistenceDates(
+        startDate: String,
+        endDate: String,
+        communityId: Int?,
+        memberId: Int?,
+        cursorId: Int?,
+        size: Int?
+    ) -> Single<[DiaryExistenceDate]>
     
     func deleteDiary(diaryId: Int) -> Single<Bool>
 }

--- a/GraceLog/Source/Domain/Usecase/Comment/DefaultCommentUseCase.swift
+++ b/GraceLog/Source/Domain/Usecase/Comment/DefaultCommentUseCase.swift
@@ -8,7 +8,12 @@
 import RxRelay
 
 final class DefaultCommentUseCase: CommentUseCase {
+    private let diaryID: Int
     var commentList = BehaviorRelay<[Comment]>(value: [])
+    
+    init(diaryID: Int) {
+        self.diaryID = diaryID
+    }
     
     func fetchCommentList() {
         commentList.accept([

--- a/GraceLog/Source/Domain/Usecase/Community/DefaultCommunityGroupUseCase.swift
+++ b/GraceLog/Source/Domain/Usecase/Community/DefaultCommunityGroupUseCase.swift
@@ -1,0 +1,12 @@
+//
+//  DefaultCommunityGroupUseCase.swift
+//  GraceLog
+//
+//  Created by 이건준 on 12/29/25.
+//
+
+import Foundation
+
+final class DefaultCommunityGroupUseCase: CommunityGroupUseCase {
+    
+}

--- a/GraceLog/Source/Domain/Usecase/Community/DefaultCommunityGroupUseCase.swift
+++ b/GraceLog/Source/Domain/Usecase/Community/DefaultCommunityGroupUseCase.swift
@@ -5,12 +5,138 @@
 //  Created by 이건준 on 12/29/25.
 //
 
-import Foundation
+import RxSwift
+import RxRelay
 
 final class DefaultCommunityGroupUseCase: CommunityGroupUseCase {
-    private let id: Int
+    var latestCommunityDiaryExistenceDate = BehaviorRelay<Date?>(value: nil)
+    var diaryExistenceDates = BehaviorRelay<[DiaryExistenceDate]>(value: [])
+    var communityDiaryList = BehaviorRelay<[CommunityDiaryPreview]>(value: [])
+    var isLastPage = BehaviorRelay<Bool>(value: false)
+    var toggleDiaryResult = PublishRelay<Bool>()
+    var error = PublishRelay<Error>()
     
-    init(id: Int) {
-        self.id = id
+    private let disposeBag = DisposeBag()
+    
+    private let diaryRepository: DiaryRepository
+    private let likeRepository: LikeRepository
+    private let communityId: Int
+    private let pageSize = 3
+    private var currentCursorId: Int?
+    private var lastFetchedDate: String?
+    
+    init(
+        diaryRepository: DiaryRepository,
+        likeRepository: LikeRepository,
+        communityId: Int
+    ) {
+        self.diaryRepository = diaryRepository
+        self.likeRepository = likeRepository
+        self.communityId = communityId
+    }
+    
+    func fetchLatestCommunityDiaryExistenceDate() {
+        diaryRepository.fetchDiaryLastPostDate(communityId: communityId)
+            .subscribe(onSuccess: {
+                self.latestCommunityDiaryExistenceDate.accept($0)
+            }, onFailure: {
+                self.error.accept($0)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func fetchCommunityDiaryExistenceDates(date: Date) {
+        let calendar = Calendar.current
+        let year = calendar.component(.year, from: date)
+        let month = calendar.component(.month, from: date)
+        let (startDate, endDate) = DateFormatterFactory.getMonthDateRange(year: year, month: month)
+        
+        diaryRepository.fetchDiaryExistenceDates(
+            startDate: startDate,
+            endDate: endDate,
+            communityId: communityId,
+            memberId: nil,
+            cursorId: nil,
+            size: nil
+        )
+        .subscribe(onSuccess: {
+            self.diaryExistenceDates.accept($0)
+        }, onFailure: {
+            self.error.accept($0)
+        })
+        .disposed(by: disposeBag)
+    }
+    
+    func fetchCommunityDiaryList(date: String) {
+        if lastFetchedDate != date {
+            resetDiaryList()
+            lastFetchedDate = date
+        }
+        loadNextPage()
+    }
+    
+    func loadNextPage() {
+        guard !isLastPage.value, let currentDate = lastFetchedDate else { return }
+        
+        let isFirstPage = currentCursorId == nil
+        
+        diaryRepository.fetchDateRangeCommunityDiaryList(
+            startDate: currentDate,
+            endDate: currentDate,
+            communityId: communityId,
+            memberId: nil,
+            cursorId: currentCursorId,
+            size: pageSize
+        )
+        .subscribe(onSuccess: {
+            self.isLastPage.accept($0.isLastPage)
+            
+            if !$0.isLastPage {
+                self.currentCursorId = $0.diaryList.last?.id
+            }
+            
+            if isFirstPage {
+                self.communityDiaryList.accept($0.diaryList)
+            } else {
+                var currentList = self.communityDiaryList.value
+                currentList.append(contentsOf: $0.diaryList)
+                self.communityDiaryList.accept(currentList)
+            }
+        }, onFailure: {
+            self.error.accept($0)
+        })
+        .disposed(by: disposeBag)
+    }
+    
+    func toggleDiaryLike(id: Int) {
+        likeRepository.likeToggle(postId: id)
+            .subscribe(onSuccess: { _ in
+                self.toggleDiaryResult.accept(true)
+                self.updateDiaryLikeStatus(id: id)
+            }, onFailure: {
+                self.toggleDiaryResult.accept(false)
+                self.error.accept($0)
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+extension DefaultCommunityGroupUseCase {
+    func resetDiaryList() {
+        communityDiaryList.accept([])
+        isLastPage.accept(false)
+        currentCursorId = nil
+    }
+    
+    private func updateDiaryLikeStatus(id: Int) {
+        var updatedList = communityDiaryList.value
+        if let index = updatedList.firstIndex(where: { $0.id == id }) {
+            var diary = updatedList[index]
+            diary.isLiked.toggle()
+            diary.likeCount = diary.isLiked ? diary.likeCount + 1 : max(0, diary.likeCount - 1)
+            
+            updatedList[index] = diary
+            communityDiaryList.accept(updatedList)
+        }
     }
 }

--- a/GraceLog/Source/Domain/Usecase/Community/DefaultCommunityGroupUseCase.swift
+++ b/GraceLog/Source/Domain/Usecase/Community/DefaultCommunityGroupUseCase.swift
@@ -8,5 +8,9 @@
 import Foundation
 
 final class DefaultCommunityGroupUseCase: CommunityGroupUseCase {
+    private let id: Int
     
+    init(id: Int) {
+        self.id = id
+    }
 }

--- a/GraceLog/Source/Domain/Usecase/Community/DefaultCreateCommunityUseCase.swift
+++ b/GraceLog/Source/Domain/Usecase/Community/DefaultCreateCommunityUseCase.swift
@@ -6,10 +6,19 @@
 //
 
 import RxRelay
+import RxSwift
 
 final class DefaultCreateCommunityUseCase: CreateCommunityUseCase {
     var maxImageCount: Int { Constants.updatableMaxImageCount }
     let createCommunityResult = PublishRelay<Result<Void, CreateCommunityError>>()
+    
+    private let disposeBag = DisposeBag()
+    
+    private let communityRepository: CommunityRepository
+    
+    init(communityRepository: CommunityRepository) {
+        self.communityRepository = communityRepository
+    }
     
     func createCommunity(title: String, images: [DiaryImage]) {
         guard !title.isEmpty else {
@@ -27,16 +36,17 @@ final class DefaultCreateCommunityUseCase: CreateCommunityUseCase {
             return
         }
         
-        // MARK: - 실제 API 연동 (TODO)
-        print("업로드된 이미지: \(images)\n작성한 제목: \(title)")
-        
-        let apiSucceeded = Bool.random()
-        
-        if apiSucceeded {
-            createCommunityResult.accept(.success(()))
-        } else {
-            createCommunityResult.accept(.failure(.apiFailure))
+        let images = images.compactMap { diaryImage in
+            diaryImage.image.jpegData(compressionQuality: 0.8)
         }
+        
+        communityRepository.createCommunity(images: images, name: title)
+            .subscribe(onSuccess: { _ in
+                self.createCommunityResult.accept(.success(()))
+            }, onFailure: { _ in
+                self.createCommunityResult.accept(.failure(.apiFailure))
+            })
+            .disposed(by: disposeBag)
     }
 }
 
@@ -44,5 +54,5 @@ enum CreateCommunityError: Error {
     case emptyTitle
     case emptyImages
     case exceedMaxImageCount(max: Int)
-    case apiFailure                   
+    case apiFailure
 }

--- a/GraceLog/Source/Domain/Usecase/Community/Protocol/CommunityGroupUseCase.swift
+++ b/GraceLog/Source/Domain/Usecase/Community/Protocol/CommunityGroupUseCase.swift
@@ -1,0 +1,12 @@
+//
+//  CommunityGroupUseCase.swift
+//  GraceLog
+//
+//  Created by 이건준 on 12/29/25.
+//
+
+import Foundation
+
+protocol CommunityGroupUseCase {
+    
+}

--- a/GraceLog/Source/Domain/Usecase/Community/Protocol/CommunityGroupUseCase.swift
+++ b/GraceLog/Source/Domain/Usecase/Community/Protocol/CommunityGroupUseCase.swift
@@ -5,8 +5,19 @@
 //  Created by 이건준 on 12/29/25.
 //
 
-import Foundation
+import RxRelay
 
 protocol CommunityGroupUseCase {
+    var latestCommunityDiaryExistenceDate: BehaviorRelay<Date?> { get }
+    var diaryExistenceDates: BehaviorRelay<[DiaryExistenceDate]> { get }
+    var communityDiaryList: BehaviorRelay<[CommunityDiaryPreview]> { get }
+    var isLastPage: BehaviorRelay<Bool> { get }
+    var toggleDiaryResult: PublishRelay<Bool> { get }
+    var error: PublishRelay<Error> { get }
     
+    func fetchLatestCommunityDiaryExistenceDate()
+    func fetchCommunityDiaryExistenceDates(date: Date)
+    func fetchCommunityDiaryList(date: String)
+    func loadNextPage()
+    func toggleDiaryLike(id: Int)
 }

--- a/GraceLog/Source/Domain/Usecase/Diary/DefaultDiaryDetailsUseCase.swift
+++ b/GraceLog/Source/Domain/Usecase/Diary/DefaultDiaryDetailsUseCase.swift
@@ -15,7 +15,7 @@ final class DefaultDiaryDetailsUseCase: DiaryDetailsUseCase {
     private let disposeBag = DisposeBag()
     
     var diary = PublishRelay<DiaryDetails>()
-    var dateRangeDiaries = BehaviorRelay<[DiaryDetails]>(value: [])
+    var postDateList = BehaviorRelay<[DiaryExistenceDate]>(value: [])
     var toggleDiaryResult = PublishRelay<Bool>()
     var error = PublishRelay<Error>()
     
@@ -26,11 +26,15 @@ final class DefaultDiaryDetailsUseCase: DiaryDetailsUseCase {
     init(
         diaryRepository: DiaryRepository,
         likeRepository: LikeRepository,
-        diaryId: Int
+        diaryId: Int,
+        communityId: Int?,
+        memberId: Int?
     ) {
         self.diaryRepository = diaryRepository
         self.likeRepository = likeRepository
         self.diaryId = diaryId
+        self.communityId = communityId
+        self.memberId = memberId
         
         fetchDiaryDetails(diaryId: diaryId)
     }
@@ -39,19 +43,11 @@ final class DefaultDiaryDetailsUseCase: DiaryDetailsUseCase {
     ///
     /// **동작 순서:**
     /// 1. 일기 ID로 단일 일기 상세 정보 조회
-    /// 2. communityId와 memberId 저장
-    /// 3. 작성 날짜(createdAt)를 기준으로 해당 월의 모든 일기 목록 조회(캘린더 마커 표시용)
-    /// 4. 일기 상세 정보를 Relay로 전달
+    /// 2. 조회한 일기의 생성날짜를 통해 해달 달에 유저가 해당 공동체에 공유한 날짜들을 조회(자신인 경우 공동체에 공유한 일기뿐 아니라 전체 조회)
+    /// 4. 캘린더에 마커된 날짜 클릭시 해당 날짜에 작성한 일기 리스트 조회(현재는 하루에 한개만 작성 가능하므로 first값)
     func fetchDiaryDetails(diaryId: Int) {
         diaryRepository.fetchDiary(diaryId: diaryId)
             .subscribe(onSuccess: { diary in
-                self.communityId = diary.communityId
-                self.memberId = diary.user.id
-                
-                if let createdAt = diary.createdAt {
-                    self.fetchDateRangeDiaryList(date: createdAt)
-                }
-                
                 self.diary.accept(diary)
             }, onFailure: { error in
                 self.error.accept(error)
@@ -59,22 +55,41 @@ final class DefaultDiaryDetailsUseCase: DiaryDetailsUseCase {
             .disposed(by: disposeBag)
     }
     
-    func fetchDateRangeDiaryList(date: Date) {
-        guard let memberId = memberId else { return }
-        
+    func fetchDiaryPostDateList(date: Date) {
         let calendar = Calendar.current
         let year = calendar.component(.year, from: date)
         let month = calendar.component(.month, from: date)
         let (startDate, endDate) = DateFormatterFactory.getMonthDateRange(year: year, month: month)
         
-        diaryRepository.fetchDateRangeDiaryList(
+        diaryRepository.fetchDiaryExistenceDates(
             startDate: startDate,
             endDate: endDate,
             communityId: communityId,
-            memberId: memberId
+            memberId: memberId,
+            cursorId: nil,
+            size: nil
+        )
+        .subscribe(onSuccess: {
+            self.postDateList.accept($0)
+        }, onFailure: {
+            self.error.accept($0)
+        })
+        .disposed(by: disposeBag)
+    }
+    
+    func fetchDateRangeDiaryList(date: String) {
+        guard let memberId = memberId else { return }
+        
+        diaryRepository.fetchDateRangeMemberDiaryList(
+            startDate: date,
+            endDate: date,
+            memberId: memberId, communityId: communityId,
+            cursorId: nil,
+            size: 1
         )
         .subscribe(onSuccess: { diaryList in
-            self.dateRangeDiaries.accept(diaryList)
+            guard let diary = diaryList.first else { return }
+            self.diary.accept(diary)
         }, onFailure: { error in
             self.error.accept(error)
         })

--- a/GraceLog/Source/Domain/Usecase/Diary/DefaultDiaryDetailsUseCase.swift
+++ b/GraceLog/Source/Domain/Usecase/Diary/DefaultDiaryDetailsUseCase.swift
@@ -15,27 +15,22 @@ final class DefaultDiaryDetailsUseCase: DiaryDetailsUseCase {
     
     var diary = PublishRelay<DiaryDetails>()
     var dateRangeDiaries = BehaviorRelay<[DiaryDetails]>(value: [])
-    var likeDiaryResult = PublishRelay<Bool>()
-    var unlikeDiaryResult = PublishRelay<Bool>()
+    var likeDiaryResult = PublishRelay<(Bool, Int)>()
+    var unlikeDiaryResult = PublishRelay<(Bool, Int)>()
     var error = PublishRelay<Error>()
     
-    private let diaryId: Int
-    private let communityId: Int = 0
-    private let memberId: Int = 0
+    private let communityId: Int
+    private let memberId: Int
     
     init(
         /// TODO: - 공동체 아이디, 유저 아이디 추후 주입 필요
         diaryRepository: DiaryRepository,
-        diaryId: Int
-//        communityId: Int,
-//        memberId: Int
+        communityId: Int,
+        memberId: Int
     ) {
         self.diaryRepository = diaryRepository
-        self.diaryId = diaryId
-//        self.communityId = communityId
-//        self.memberId = memberId
-        
-        fetchDiaryDetails(diaryId: diaryId)
+        self.communityId = communityId
+        self.memberId = memberId
     }
     
     func fetchDiaryDetails(diaryId: Int) {
@@ -52,46 +47,177 @@ final class DefaultDiaryDetailsUseCase: DiaryDetailsUseCase {
         startDate: String,
         endDate: String
     ) {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        
-        guard let start = dateFormatter.date(from: startDate),
-              let end = dateFormatter.date(from: endDate) else {
-            dateRangeDiaries.accept([])
-            return
-        }
-        
-        diaryRepository.fetchDateRangeDiaryList(
-            startDate: start,
-            endDate: end,
-            communityId: communityId,
-            memberId: memberId
-        )
-        .subscribe(onSuccess: { diaryList in
-            self.dateRangeDiaries.accept(diaryList)
-        }, onFailure: { error in
-            self.error.accept(error)
-        })
-        .disposed(by: disposeBag)
+        let mockUsers: [GraceLogUser] = [
+            GraceLogUser(
+                id: 1,
+                name: "이건준",
+                nickname: "geonjun",
+                profileImageURL: URL(string: "https://example.com/profile1.png"),
+                email: "geonjun@example.com",
+                message: "오늘도 기록합니다."
+            ),
+            GraceLogUser(
+                id: 2,
+                name: "김지희",
+                nickname: "jihui",
+                profileImageURL: URL(string: "https://example.com/profile2.png"),
+                email: "jihui@example.com",
+                message: "소소한 일상의 기록"
+            ),
+            GraceLogUser(
+                id: 3,
+                name: "박민수",
+                nickname: "minsoo",
+                profileImageURL: URL(string: "https://example.com/profile3.png"),
+                email: "minsoo@example.com",
+                message: "개발과 일상의 균형"
+            ),
+            GraceLogUser(
+                id: 4,
+                name: "최서연",
+                nickname: "seoyeon",
+                profileImageURL: nil,
+                email: "seoyeon@example.com",
+                message: "비 오는 날을 좋아해요"
+            ),
+            GraceLogUser(
+                id: 5,
+                name: "테스트유저",
+                nickname: "tester",
+                profileImageURL: nil,
+                email: "tester@example.com",
+                message: "임시 계정입니다"
+            )
+        ]
+        let mockDiaryDetailsList: [DiaryDetails] = [
+            DiaryDetails(
+                diaryId: 1,
+                title: "첫 번째 일기",
+                description: "오늘은 날씨가 좋아서 산책을 다녀왔다.",
+                user: mockUsers[0],
+                imageURLs: [
+                    URL(string: "https://example.com/image1.png")
+                ],
+                likeCount: 12,
+                likeByMe: true,
+                isHideLike: false,
+                isHideComment: false,
+                commentCount: 3,
+                createdAt: Calendar.current.date(
+                    from: DateComponents(year: 2025, month: 3, day: 10, hour: 9)
+                )
+            ),
+            DiaryDetails(
+                diaryId: 2,
+                title: "두 번째 일기",
+                description: "점심에 맛있는 파스타를 먹었다.",
+                user: mockUsers[1],
+                imageURLs: [
+                    URL(string: "https://example.com/image2.png"),
+                    URL(string: "https://example.com/image3.png")
+                ],
+                likeCount: 8,
+                likeByMe: false,
+                isHideLike: false,
+                isHideComment: false,
+                commentCount: 1,
+                createdAt: Calendar.current.date(
+                    from: DateComponents(year: 2025, month: 3, day: 10, hour: 21)
+                )
+            ),
+            DiaryDetails(
+                diaryId: 3,
+                title: "세 번째 일기",
+                description: "프로젝트 마감 때문에 하루 종일 코딩했다.",
+                user: mockUsers[2],
+                imageURLs: [],
+                likeCount: 20,
+                likeByMe: true,
+                isHideLike: false,
+                isHideComment: false,
+                commentCount: 5,
+                createdAt: Calendar.current.date(
+                    from: DateComponents(year: 2025, month: 3, day: 11, hour: 1)
+                )
+            ),
+            DiaryDetails(
+                diaryId: 4,
+                title: "네 번째 일기",
+                description: "비 오는 날이라 집에서 책을 읽었다.",
+                user: mockUsers[3],
+                imageURLs: [
+                    URL(string: "https://example.com/image4.png")
+                ],
+                likeCount: 5,
+                likeByMe: false,
+                isHideLike: false,
+                isHideComment: true,
+                commentCount: 0,
+                createdAt: Calendar.current.date(
+                    from: DateComponents(year: 2026, month: 2, day: 12, hour: 14)
+                )
+            ),
+            DiaryDetails(
+                diaryId: 5,
+                title: "날짜 없는 일기",
+                description: "임시 저장된 일기라 날짜가 없다.",
+                user: mockUsers[4],
+                imageURLs: [],
+                likeCount: 0,
+                likeByMe: false,
+                isHideLike: true,
+                isHideComment: true,
+                commentCount: 0,
+                createdAt: Calendar.current.date(
+                    from: DateComponents(year: 2026, month: 1, day: 4, hour: 14)
+                )
+            )
+        ]
+
+
+        dateRangeDiaries.accept(mockDiaryDetailsList)
+//        let dateFormatter = DateFormatter()
+//        dateFormatter.dateFormat = "yyyy-MM-dd"
+//        
+//        guard let start = dateFormatter.date(from: startDate),
+//              let end = dateFormatter.date(from: endDate) else {
+//            dateRangeDiaries.accept([])
+//            return
+//        }
+//        
+//        diaryRepository.fetchDateRangeDiaryList(
+//            startDate: start,
+//            endDate: end,
+//            communityId: communityId,
+//            memberId: memberId
+//        )
+//        .subscribe(onSuccess: { diaryList in
+//            self.dateRangeDiaries.accept(diaryList)
+//        }, onFailure: { error in
+//            self.error.accept(error)
+//        })
+//        .disposed(by: disposeBag)
     }
     
     func likeDiary(id: Int) {
-        diaryRepository.likeToggle(postId: id)
-            .subscribe(onSuccess: { result in
-                self.likeDiaryResult.accept(result)
-            }, onFailure: { error in
-                self.error.accept(error)
-            })
-            .disposed(by: disposeBag)
+        likeDiaryResult.accept((true, id))
+//        diaryRepository.likeToggle(postId: id)
+//            .subscribe(onSuccess: { result in
+//                self.likeDiaryResult.accept((result, id))
+//            }, onFailure: { error in
+//                self.error.accept(error)
+//            })
+//            .disposed(by: disposeBag)
     }
     
     func unlikeDiary(id: Int) {
-        diaryRepository.likeToggle(postId: id)
-            .subscribe(onSuccess: { result in
-                self.likeDiaryResult.accept(result)
-            }, onFailure: { error in
-                self.error.accept(error)
-            })
-            .disposed(by: disposeBag)
+        likeDiaryResult.accept((false, id))
+//        diaryRepository.likeToggle(postId: id)
+//            .subscribe(onSuccess: { result in
+//                self.likeDiaryResult.accept((result, id))
+//            }, onFailure: { error in
+//                self.error.accept(error)
+//            })
+//            .disposed(by: disposeBag)
     }
 }

--- a/GraceLog/Source/Domain/Usecase/Diary/Protocol/DiaryDetailsUseCase.swift
+++ b/GraceLog/Source/Domain/Usecase/Diary/Protocol/DiaryDetailsUseCase.swift
@@ -9,11 +9,12 @@ import RxRelay
 
 protocol DiaryDetailsUseCase {
     var diary: PublishRelay<DiaryDetails> { get }
-    var dateRangeDiaries: BehaviorRelay<[DiaryDetails]> { get }
+    var postDateList: BehaviorRelay<[DiaryExistenceDate]> { get }
     var toggleDiaryResult: PublishRelay<Bool> { get }
     var error: PublishRelay<Error> { get }
     
     func fetchDiaryDetails(diaryId: Int)
-    func fetchDateRangeDiaryList(date: Date)
+    func fetchDiaryPostDateList(date: Date)
+    func fetchDateRangeDiaryList(date: String)
     func toggleDiaryLike(id: Int)
 }

--- a/GraceLog/Source/Domain/Usecase/Diary/Protocol/DiaryDetailsUseCase.swift
+++ b/GraceLog/Source/Domain/Usecase/Diary/Protocol/DiaryDetailsUseCase.swift
@@ -10,8 +10,8 @@ import RxRelay
 protocol DiaryDetailsUseCase {
     var diary: PublishRelay<DiaryDetails> { get }
     var dateRangeDiaries: BehaviorRelay<[DiaryDetails]> { get }
-    var likeDiaryResult: PublishRelay<Bool> { get }
-    var unlikeDiaryResult: PublishRelay<Bool> { get }
+    var likeDiaryResult: PublishRelay<(Bool, Int)> { get }
+    var unlikeDiaryResult: PublishRelay<(Bool, Int)> { get }
     
     func fetchDiaryDetails(diaryId: Int)
     func fetchDateRangeDiaryList(startDate: String, endDate: String)

--- a/GraceLog/Source/Domain/Usecase/Home/DefaultHomeCommunityUseCase.swift
+++ b/GraceLog/Source/Domain/Usecase/Home/DefaultHomeCommunityUseCase.swift
@@ -99,9 +99,8 @@ extension DefaultHomeCommunityUseCase {
         var updatedList = diaryList.value
         if let index = updatedList.firstIndex(where: { $0.id == id }) {
             var diary = updatedList[index]
-            
             diary.isLiked.toggle()
-            diary.likeCount += diary.isLiked ? 1 : -1
+            diary.likeCount = diary.isLiked ? diary.likeCount + 1 : max(0, diary.likeCount - 1)
             
             updatedList[index] = diary
             diaryList.accept(updatedList)

--- a/GraceLog/Source/Presentation/CoreTab/DiaryScene/Coordinator/DiaryDetailsCoordinator.swift
+++ b/GraceLog/Source/Presentation/CoreTab/DiaryScene/Coordinator/DiaryDetailsCoordinator.swift
@@ -13,20 +13,26 @@ final class DiaryDetailsCoordinator: Coordinator {
     var navigationController: UINavigationController
     
     private let diaryId: Int
+    private let communityId: Int?
+    private let memberId: Int?
     
     init(
         _ navigationController: UINavigationController,
-        diaryId: Int
+        diaryId: Int,
+        communityId: Int?,
+        memberId: Int?
     ) {
         self.navigationController = navigationController
         self.diaryId = diaryId
+        self.communityId = communityId
+        self.memberId = memberId
     }
     
     func start() {
         let diaryDetailsVC = DependencyContainer.shared.injector.resolve(
             DiaryDetailsViewController.self,
             arguments: self as DiaryDetailsCoordinator,
-            diaryId
+            diaryId, communityId, memberId
         )
         self.navigationController.pushViewController(diaryDetailsVC, animated: true)
     }

--- a/GraceLog/Source/Presentation/CoreTab/DiaryScene/Coordinator/DiaryDetailsCoordinator.swift
+++ b/GraceLog/Source/Presentation/CoreTab/DiaryScene/Coordinator/DiaryDetailsCoordinator.swift
@@ -34,7 +34,7 @@ final class DiaryDetailsCoordinator: Coordinator {
     func showCommentBottomSheet() {
         let commentBottomSheetVC = CommentBottomSheetViewController(
             reactor: CommentBottomSheetViewReactor(
-                usecase: DefaultCommentUseCase()
+                usecase: DefaultCommentUseCase(diaryID: diaryId)
             )
         )
         self.navigationController.present(commentBottomSheetVC, animated: true)

--- a/GraceLog/Source/Presentation/CoreTab/DiaryScene/Reactor/DiaryDetailsViewReactor.swift
+++ b/GraceLog/Source/Presentation/CoreTab/DiaryScene/Reactor/DiaryDetailsViewReactor.swift
@@ -24,14 +24,14 @@ final class DiaryDetailsViewReactor: Reactor {
     enum Mutation {
         case setDiary(DiaryDetails)
         case setDateRangeDiaryList([DiaryDetails])
-        case setDiaryLikeResult(isSuccess: Bool)
-        case setDiaryUnlikeResult(isSuccess: Bool)
+        case setDiaryLikeResult((isSuccess: Bool, diaryID: Int))
+        case setDiaryUnlikeResult((isSuccess: Bool, diaryID: Int))
     }
     struct State {
         @Pulse var diary: DiaryDetails?
         @Pulse var dateRangeDiaries: [DiaryDetails]
-        @Pulse var isSuccessLikeResult: Bool?
-        @Pulse var isSuccessUnlikeResult: Bool?
+        @Pulse var isSuccessLikeResult: (Bool, Int)?
+        @Pulse var isSuccessUnlikeResult: (Bool, Int)?
     }
     
     init(
@@ -101,10 +101,10 @@ extension DiaryDetailsViewReactor {
             .map { Mutation.setDateRangeDiaryList($0) }
         
         let likeResult = usecase.likeDiaryResult
-            .map { result in Mutation.setDiaryLikeResult(isSuccess: result) }
+            .map { Mutation.setDiaryLikeResult((isSuccess: $0.0, diaryID: $0.1)) }
         
         let unlikeResult = usecase.unlikeDiaryResult
-            .map { result in Mutation.setDiaryUnlikeResult(isSuccess: result) }
+            .map { Mutation.setDiaryUnlikeResult((isSuccess: $0.0, diaryID: $0.1)) }
         
         return Observable.merge(
             fetchDiaryDetail,

--- a/GraceLog/Source/Presentation/CoreTab/DiaryScene/Reactor/DiaryDetailsViewReactor.swift
+++ b/GraceLog/Source/Presentation/CoreTab/DiaryScene/Reactor/DiaryDetailsViewReactor.swift
@@ -15,6 +15,7 @@ final class DiaryDetailsViewReactor: Reactor {
     
     enum Action {
         case fetchDiary(Int)
+        case fetchPostDateList(Date)
         case fetchDateRangeDiaryList(Date)
         case didTapBackButton
         case didTapLikeButton(Int)
@@ -23,13 +24,13 @@ final class DiaryDetailsViewReactor: Reactor {
     
     enum Mutation {
         case setDiary(DiaryDetails)
-        case setDateRangeDiaryList([DiaryDetails])
+        case setPostDateList([DiaryExistenceDate])
         case toggleLike
         case setError(Error)
     }
     struct State {
         @Pulse var diary: DiaryDetails?
-        @Pulse var dateRangeDiaries: [DiaryDetails]
+        @Pulse var postDateList: [Date]
         @Pulse var error: Error?
     }
     
@@ -41,7 +42,7 @@ final class DiaryDetailsViewReactor: Reactor {
         self.usecase = usecase
         
         self.initialState = State(
-            dateRangeDiaries: []
+            postDateList: []
         )
     }
 }
@@ -51,10 +52,10 @@ extension DiaryDetailsViewReactor {
         switch action {
         case .fetchDiary(let diaryId):
             usecase.fetchDiaryDetails(diaryId: diaryId)
+        case .fetchPostDateList(let date):
+            usecase.fetchDiaryPostDateList(date: date)
         case .fetchDateRangeDiaryList(let date):
-            usecase.fetchDateRangeDiaryList(
-                date: date
-            )
+            usecase.fetchDateRangeDiaryList(date: DateFormatterFactory.toDateOnlyString(from: date))
         case .didTapBackButton:
             coordinator.popViewController()
         case .didTapLikeButton(let diaryID):
@@ -72,8 +73,8 @@ extension DiaryDetailsViewReactor {
         switch mutation {
         case .setDiary(let diary):
             newState.diary = diary
-        case .setDateRangeDiaryList(let diaryList):
-            newState.dateRangeDiaries = diaryList
+        case .setPostDateList(let dates):
+            newState.postDateList = dates.map { $0.date }
         case .toggleLike:
             if var diary = newState.diary {
                 diary.likeByMe.toggle()
@@ -92,15 +93,15 @@ extension DiaryDetailsViewReactor {
         let fetchDiaryDetail = usecase.diary
             .map { Mutation.setDiary($0) }
         
-        let fetchDateRangeDiaryList = usecase.dateRangeDiaries
-            .map { Mutation.setDateRangeDiaryList($0) }
+        let postDateListMutation = usecase.postDateList
+            .map { Mutation.setPostDateList($0) }
         
         let errorMuataion = usecase.error
             .map { Mutation.setError($0) }
         
         return Observable.merge(
             fetchDiaryDetail,
-            fetchDateRangeDiaryList,
+            postDateListMutation,
             errorMuataion,
             mutation
         )

--- a/GraceLog/Source/Presentation/CoreTab/DiaryScene/ViewController/DiaryDetailsViewController.swift
+++ b/GraceLog/Source/Presentation/CoreTab/DiaryScene/ViewController/DiaryDetailsViewController.swift
@@ -194,8 +194,6 @@ final class DiaryDetailsViewController: GraceLogBaseViewController<DiaryDetailsV
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, error in
                 owner.view.makeToast(error.localizedDescription)
-            }
-            .disposed(by: disposeBag)
     }
 }
 

--- a/GraceLog/Source/Presentation/CoreTab/DiaryScene/ViewController/DiaryDetailsViewController.swift
+++ b/GraceLog/Source/Presentation/CoreTab/DiaryScene/ViewController/DiaryDetailsViewController.swift
@@ -182,7 +182,15 @@ final class DiaryDetailsViewController: GraceLogBaseViewController<DiaryDetailsV
             }
             .disposed(by: disposeBag)
         
-        reactor.pulse(\.$dateRangeDiaries)
+        diaryObservable
+            .compactMap { $0 }
+            .subscribe(with: self) { owner, diary in
+                guard let date = diary.createdAt else { return }
+                reactor.action.onNext(.fetchPostDateList(date))
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$postDateList)
             .asDriver(onErrorJustReturn: [])
             .drive(with: self) { owner, _ in
                 owner.calendarView.reloadData()
@@ -222,39 +230,26 @@ extension DiaryDetailsViewController: FSCalendarDelegate, FSCalendarDataSource {
         config?.title = DateFormatterFactory.toYearMonthString(from: calendar.currentPage)
         calendarButton.configuration = config
         
-        reactor?.action.onNext(.fetchDateRangeDiaryList(calendar.currentPage))
+        reactor?.action.onNext(.fetchPostDateList(calendar.currentPage))
     }
     
     /// 감사일기가 작성된 날짜 마커
     func calendar(_ calendar: FSCalendar, numberOfEventsFor date: Date) -> Int {
-        guard let diaryList = reactor?.currentState.dateRangeDiaries else { return 0 }
+        guard let dateList = reactor?.currentState.postDateList else { return 0 }
         
-        let hasEvent = diaryList.contains(where: {
-            guard let createdAt = $0.createdAt else { return false }
-            return Calendar.current.isDate(createdAt, inSameDayAs: date)
-        })
-        
+        let hasEvent = dateList.contains(where: { return Calendar.current.isDate($0, inSameDayAs: date) })
         return hasEvent ? 1 : 0
     }
     
     /// 날짜 선택 가능 여부 결정
     func calendar(_ calendar: FSCalendar, shouldSelect date: Date, at monthPosition: FSCalendarMonthPosition) -> Bool {
-        guard let diaryList = reactor?.currentState.dateRangeDiaries else { return false }
+        guard let dateList = reactor?.currentState.postDateList else { return false }
         
-        let hasEvent = diaryList.contains(where: {
-            guard let createdAt = $0.createdAt else { return false }
-            return Calendar.current.isDate(createdAt, inSameDayAs: date)
-        })
-        
+        let hasEvent = dateList.contains(where: { return Calendar.current.isDate($0, inSameDayAs: date) })
         return hasEvent
     }
     
     func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
-        if let selectedDiary = reactor?.currentState.dateRangeDiaries.first(where: {
-            guard let createdAt = $0.createdAt else { return false }
-            return Calendar.current.isDate(createdAt, inSameDayAs: date)
-        }) {
-            reactor?.action.onNext(.fetchDiary(selectedDiary.diaryId))
-        }
+        reactor?.action.onNext(.fetchDateRangeDiaryList(date))
     }
 }

--- a/GraceLog/Source/Presentation/CoreTab/DiaryScene/ViewController/DiaryDetailsViewController.swift
+++ b/GraceLog/Source/Presentation/CoreTab/DiaryScene/ViewController/DiaryDetailsViewController.swift
@@ -197,7 +197,8 @@ final class DiaryDetailsViewController: GraceLogBaseViewController<DiaryDetailsV
         
         reactor.pulse(\.$isSuccessLikeResult)
             .compactMap { $0 }
-            .subscribe(with: self) { owner, isSuccess in
+            .subscribe(with: self) { owner, result in
+                let (isSuccess, diaryID) = result
                 // TODO: - 좋아요 성공여부에 따른 로직 구현
                 if isSuccess {
                     print("좋아요 성공!")
@@ -209,7 +210,8 @@ final class DiaryDetailsViewController: GraceLogBaseViewController<DiaryDetailsV
         
         reactor.pulse(\.$isSuccessUnlikeResult)
             .compactMap { $0 }
-            .subscribe(with: self) { owner, isSuccess in
+            .subscribe(with: self) { owner, result in
+                let (isSuccess, diaryID) = result
                 // TODO: - 좋아요 성공여부에 따른 로직 구현
                 if isSuccess {
                     print("좋아요 해제 성공!")

--- a/GraceLog/Source/Presentation/CoreTab/HomeScene/Coordinator/HomeCoordinator.swift
+++ b/GraceLog/Source/Presentation/CoreTab/HomeScene/Coordinator/HomeCoordinator.swift
@@ -24,10 +24,12 @@ final class HomeCoordinator: NavigationCoordinator {
         navigationController.setViewControllers([viewController], animated: false)
     }
     
-    func showDiaryDetail(diaryId: Int) {
+    func showDiaryDetail(diaryId: Int, communityId: Int?, memberId: Int?) {
         let diaryDetailsCoordinator = DiaryDetailsCoordinator(
             self.navigationController,
-            diaryId: diaryId
+            diaryId: diaryId,
+            communityId: communityId,
+            memberId: memberId
         )
         diaryDetailsCoordinator.parentCoordinator = self
         self.childCoordinators.append(diaryDetailsCoordinator)

--- a/GraceLog/Source/Presentation/CoreTab/HomeScene/DataSource/HomeCommunityDiarySection.swift
+++ b/GraceLog/Source/Presentation/CoreTab/HomeScene/DataSource/HomeCommunityDiarySection.swift
@@ -11,12 +11,14 @@ import UIKit
 struct CommunityDiaryItem {
     let id: Int
     let isCurrentUser: Bool
+    let userId: Int
     let username: String
     let title: String
     let content: String
     var likeCount: Int
     var commentCount: Int
     var isLiked: Bool
+    let communityId: Int?
     let profileImageURL: URL?
     let cardImageURL: URL?
     let editedDate: String
@@ -24,12 +26,14 @@ struct CommunityDiaryItem {
     init(from: CommunityDiaryPreview) {
         self.id = from.id
         self.isCurrentUser = from.isCurrentUser
+        self.userId = from.userId
         self.username = from.username
         self.title = from.title
         self.content = from.content
         self.likeCount = from.likeCount
         self.commentCount = from.commentCount
         self.isLiked = from.isLiked
+        self.communityId = from.communityId
         self.profileImageURL = from.profileImageURL
         self.cardImageURL = from.diaryImageURL
         self.editedDate = ""

--- a/GraceLog/Source/Presentation/CoreTab/HomeScene/DataSource/HomeCommunityDiarySection.swift
+++ b/GraceLog/Source/Presentation/CoreTab/HomeScene/DataSource/HomeCommunityDiarySection.swift
@@ -36,6 +36,16 @@ struct CommunityDiaryItem {
     }
 }
 
+extension CommunityDiaryItem: IdentifiableType, Equatable {
+    typealias Identity = Int
+    var identity: Int { id }
+
+    static func == (lhs: CommunityDiaryItem, rhs: CommunityDiaryItem) -> Bool {
+        return lhs.id == rhs.id &&
+               lhs.isLiked == rhs.isLiked
+    }
+}
+
 struct HomeCommunityDiarySection {
     let date: String
     var items: [CommunityDiaryItem]

--- a/GraceLog/Source/Presentation/CoreTab/HomeScene/Reactor/HomeCommunityViewReactor.swift
+++ b/GraceLog/Source/Presentation/CoreTab/HomeScene/Reactor/HomeCommunityViewReactor.swift
@@ -19,7 +19,7 @@ final class HomeCommunityViewReactor: Reactor {
     
     enum Action {
         case didSelectCommunity(Community)
-        case didTapDiaryDetail(Int)
+        case didTapDiaryDetail(Int, Int?, Int?)
         case didTapLikeButton(Int)
         case loadMoreDiaries
     }
@@ -33,8 +33,6 @@ final class HomeCommunityViewReactor: Reactor {
     struct State {
         @Pulse var communityList: [Community]
         @Pulse var sectionedDiaryList: [HomeCommunityDiarySection]
-        @Pulse var isSuccessLikeDiary: Bool?
-        @Pulse var isSuccessUnlikeResult: Bool?
         @Pulse var error: Error?
     }
     
@@ -59,8 +57,12 @@ extension HomeCommunityViewReactor {
             usecase.fetchDiaryList(
                 communityId: community.id
             )
-        case .didTapDiaryDetail(let diaryID):
-            coordinator?.showDiaryDetail(diaryId: diaryID)
+        case .didTapDiaryDetail(let diaryId, let communityId, let memberId):
+            coordinator?.showDiaryDetail(
+                diaryId: diaryId,
+                communityId: communityId,
+                memberId: memberId
+            )
         case .didTapLikeButton(let diaryID):
             usecase.toggleDiaryLike(id: diaryID)
         case .loadMoreDiaries:

--- a/GraceLog/Source/Presentation/CoreTab/HomeScene/Reactor/HomeMyViewReactor.swift
+++ b/GraceLog/Source/Presentation/CoreTab/HomeScene/Reactor/HomeMyViewReactor.swift
@@ -30,7 +30,7 @@ final class HomeMyViewReactor: Reactor {
     }
     
     enum Action {
-        case didTapDiaryDetail(Int)
+        case didTapDiaryDetail(Int, Int?, Int?)
         case refreshDiaryList
     }
     
@@ -83,8 +83,12 @@ extension HomeMyViewReactor {
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .didTapDiaryDetail(let id):
-            coordinator?.showDiaryDetail(diaryId: id)
+        case .didTapDiaryDetail(let diaryId, let communityId, let memberId):
+            coordinator?.showDiaryDetail(
+                diaryId: diaryId,
+                communityId: communityId,
+                memberId: memberId
+            )
         case .refreshDiaryList:
             homeUsecase.fetchDiaryList()
             return .just(.showToast("일기가 성공적으로 공유되었습니다!"))

--- a/GraceLog/Source/Presentation/CoreTab/HomeScene/View/Community/Cells/HomeCommunityDiaryTableViewCell.swift
+++ b/GraceLog/Source/Presentation/CoreTab/HomeScene/View/Community/Cells/HomeCommunityDiaryTableViewCell.swift
@@ -22,7 +22,6 @@ final class HomeCommunityDiaryTableViewCell: UITableViewCell {
         $0.alignment = .fill
         $0.backgroundColor = .clear
         $0.isLayoutMarginsRelativeArrangement = true
-        $0.layoutMargins = .init(top: .zero, left: 20, bottom: .zero, right: 20)
         $0.spacing = 10
     }
     

--- a/GraceLog/Source/Presentation/CoreTab/HomeScene/View/Community/HomeCommunityListView.swift
+++ b/GraceLog/Source/Presentation/CoreTab/HomeScene/View/Community/HomeCommunityListView.swift
@@ -14,7 +14,7 @@ final class HomeCommunityListView: UIView {
     private let communityListLayout = UICollectionViewFlowLayout().then {
         $0.scrollDirection = .horizontal
         $0.minimumLineSpacing = 9
-        $0.sectionInset = UIEdgeInsets(top: 27, left: 18, bottom: 23, right: 18)
+        $0.sectionInset = UIEdgeInsets(top: 27, left: 0, bottom: 23, right: 0)
         $0.itemSize = CGSize(width: 64, height: 87)
     }
     

--- a/GraceLog/Source/Presentation/CoreTab/HomeScene/ViewController/HomeCommunityViewController.swift
+++ b/GraceLog/Source/Presentation/CoreTab/HomeScene/ViewController/HomeCommunityViewController.swift
@@ -169,7 +169,11 @@ extension HomeCommunityViewController {
                             return
                         }
                         
-                        reactor.action.onNext(.didTapDiaryDetail(selectedItem.id))
+                        reactor.action.onNext(.didTapDiaryDetail(
+                            selectedItem.id,
+                            selectedItem.communityId,
+                            selectedItem.userId
+                        ))
                     })
                     .disposed(by: cell.disposeBag)
                 

--- a/GraceLog/Source/Presentation/CoreTab/HomeScene/ViewController/HomeCommunityViewController.swift
+++ b/GraceLog/Source/Presentation/CoreTab/HomeScene/ViewController/HomeCommunityViewController.swift
@@ -27,6 +27,8 @@ final class HomeCommunityViewController: GraceLogBaseViewController<HomeCommunit
         $0.backgroundColor = .clear
         $0.distribution = .fill
         $0.alignment = .fill
+        $0.isLayoutMarginsRelativeArrangement = true
+        $0.layoutMargins = .init(top: .zero, left: 20, bottom: .zero, right: 20)
     }
     
     private let communitySelectedView = HomeCommunityListView()
@@ -39,7 +41,7 @@ final class HomeCommunityViewController: GraceLogBaseViewController<HomeCommunit
     
     override func setupLayouts() {
         super.setupLayouts()
-        view.addSubview(scrollView)
+        contentView.addSubview(scrollView)
         
         let subviews = [communitySelectedView, communityDiaryListView]
         containerStackView.arrangedSubviews(subviews)
@@ -50,7 +52,7 @@ final class HomeCommunityViewController: GraceLogBaseViewController<HomeCommunit
     override func setupConstraints() {
         super.setupConstraints()
         scrollView.snp.makeConstraints {
-            $0.directionalEdges.width.equalToSuperview()
+            $0.directionalEdges.equalToSuperview()
         }
         
         containerStackView.snp.makeConstraints {

--- a/GraceLog/Source/Presentation/CoreTab/HomeScene/ViewController/HomeMyViewController.swift
+++ b/GraceLog/Source/Presentation/CoreTab/HomeScene/ViewController/HomeMyViewController.swift
@@ -180,7 +180,9 @@ extension HomeMyViewController {
                               let selectedItem = try? self.myDiaryView.diaryCollectionView.rx.model(at: indexPath) as MyDiaryPreview else {
                             return
                         }
-                        reactor.action.onNext(.didTapDiaryDetail(selectedItem.id))
+                        reactor.action.onNext(.didTapDiaryDetail(
+                            selectedItem.id, nil, selectedItem.userId)
+                        )
                     })
                     .disposed(by: cell.disposeBag)
                 

--- a/GraceLog/Source/Presentation/SearchScene/Coordinator/CommunityGroupCoordinator.swift
+++ b/GraceLog/Source/Presentation/SearchScene/Coordinator/CommunityGroupCoordinator.swift
@@ -8,15 +8,25 @@
 import UIKit
 
 final class CommunityGroupCoordinator: NavigationCoordinator {
+    private let id: Int
     weak var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
     
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController, id: Int) {
         self.navigationController = navigationController
+        self.id = id
     }
     
     func start() {
-        
+        let viewController = CommunityGroupViewController(reactor: CommunityGroupReactor(usecase: DefaultCommunityGroupUseCase(id: id), coordinator: self))
+        navigationController.pushViewController(viewController, animated: true)
+    }
+}
+
+extension CommunityGroupCoordinator {
+    func popViewController() {
+        navigationController.popViewController(animated: true)
+        parentCoordinator?.removeChildCoordinator(self)
     }
 }

--- a/GraceLog/Source/Presentation/SearchScene/Coordinator/CommunityGroupCoordinator.swift
+++ b/GraceLog/Source/Presentation/SearchScene/Coordinator/CommunityGroupCoordinator.swift
@@ -8,23 +8,34 @@
 import UIKit
 
 final class CommunityGroupCoordinator: NavigationCoordinator {
-    private let id: Int
+    private let communityId: Int
+    private let memberId: Int
     weak var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
     
-    init(navigationController: UINavigationController, id: Int) {
+    init(navigationController: UINavigationController, communityId: Int, memberId: Int) {
         self.navigationController = navigationController
-        self.id = id
+        self.communityId = communityId
+        self.memberId = memberId
     }
     
     func start() {
-        let viewController = CommunityGroupViewController(reactor: CommunityGroupReactor(usecase: DefaultCommunityGroupUseCase(id: id), coordinator: self))
+        let viewController = CommunityGroupViewController(reactor: CommunityGroupReactor(diaryDetailUseCase: DefaultDiaryDetailsUseCase(diaryRepository: DefaultDiaryRepository(network: .init()), communityId: communityId, memberId: memberId), coordinator: self))
         navigationController.pushViewController(viewController, animated: true)
     }
 }
 
 extension CommunityGroupCoordinator {
+    func showCommentBottomSheet(diaryID: Int) {
+        let commentBottomSheetVC = CommentBottomSheetViewController(
+            reactor: CommentBottomSheetViewReactor(
+                usecase: DefaultCommentUseCase(diaryID: diaryID)
+            )
+        )
+        self.navigationController.present(commentBottomSheetVC, animated: true)
+    }
+    
     func popViewController() {
         navigationController.popViewController(animated: true)
         parentCoordinator?.removeChildCoordinator(self)

--- a/GraceLog/Source/Presentation/SearchScene/Coordinator/CommunityGroupCoordinator.swift
+++ b/GraceLog/Source/Presentation/SearchScene/Coordinator/CommunityGroupCoordinator.swift
@@ -21,7 +21,9 @@ final class CommunityGroupCoordinator: NavigationCoordinator {
     }
     
     func start() {
-        let viewController = CommunityGroupViewController(reactor: CommunityGroupReactor(diaryDetailUseCase: DefaultDiaryDetailsUseCase(diaryRepository: DefaultDiaryRepository(network: .init()), communityId: communityId, memberId: memberId), coordinator: self))
+        let viewController = DependencyContainer.shared.injector
+            .resolve(CommunityGroupViewController.self, argument: communityId)
+        viewController.reactor?.coordinator = self
         navigationController.pushViewController(viewController, animated: true)
     }
 }
@@ -39,5 +41,17 @@ extension CommunityGroupCoordinator {
     func popViewController() {
         navigationController.popViewController(animated: true)
         parentCoordinator?.removeChildCoordinator(self)
+    }
+    
+    func showDiaryDetail(diaryId: Int, communityId: Int?, memberId: Int?) {
+        let diaryDetailsCoordinator = DiaryDetailsCoordinator(
+            self.navigationController,
+            diaryId: diaryId,
+            communityId: communityId,
+            memberId: memberId
+        )
+        diaryDetailsCoordinator.parentCoordinator = self
+        self.childCoordinators.append(diaryDetailsCoordinator)
+        diaryDetailsCoordinator.start()
     }
 }

--- a/GraceLog/Source/Presentation/SearchScene/Coordinator/CommunityGroupCoordinator.swift
+++ b/GraceLog/Source/Presentation/SearchScene/Coordinator/CommunityGroupCoordinator.swift
@@ -1,0 +1,22 @@
+//
+//  CommunityGroupCoordinator.swift
+//  GraceLog
+//
+//  Created by 이건준 on 12/29/25.
+//
+
+import UIKit
+
+final class CommunityGroupCoordinator: NavigationCoordinator {
+    weak var parentCoordinator: Coordinator?
+    var childCoordinators: [Coordinator] = []
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+        
+    }
+}

--- a/GraceLog/Source/Presentation/SearchScene/Coordinator/CreateCommunityCoordinator.swift
+++ b/GraceLog/Source/Presentation/SearchScene/Coordinator/CreateCommunityCoordinator.swift
@@ -17,8 +17,9 @@ final class CreateCommunityCoordinator: NavigationCoordinator {
     }
     
     func start() {
-        let viewController = CreateCommunityViewController(reactor: CreateCommunityReactor(usecase: DefaultCreateCommunityUseCase(), coordinator: CreateCommunityCoordinator(navigationController: self.navigationController)))
-        navigationController.pushViewController(viewController, animated: true)
+        let createCommunityVC = DependencyContainer.shared.injector.resolve(CreateCommunityViewController.self)
+        createCommunityVC.reactor?.coordinator = self
+        navigationController.pushViewController(createCommunityVC, animated: true)
     }
 }
 
@@ -26,5 +27,10 @@ extension CreateCommunityCoordinator {
     func popViewController() {
         navigationController.popViewController(animated: true)
         parentCoordinator?.removeChildCoordinator(self)
+    }
+    
+    func createCommunityEvent() {
+        NotificationCenterManager.reloadCommunityList.post()
+        navigationController.popViewController(animated: true)
     }
 }

--- a/GraceLog/Source/Presentation/SearchScene/Coordinator/SearchCoordinator.swift
+++ b/GraceLog/Source/Presentation/SearchScene/Coordinator/SearchCoordinator.swift
@@ -31,8 +31,8 @@ extension SearchCoordinator {
         print("선택한 채팅방 아이디: \(id)")
     }
     
-    func showCommunityViewController(id: Int) {
-        let coordinator = CommunityGroupCoordinator(navigationController: self.navigationController, id: id)
+    func showCommunityViewController(communityId: Int, memberId: Int) {
+        let coordinator = CommunityGroupCoordinator(navigationController: self.navigationController, communityId: communityId, memberId: memberId)
         childCoordinators.append(coordinator)
         coordinator.start()
     }

--- a/GraceLog/Source/Presentation/SearchScene/Coordinator/SearchCoordinator.swift
+++ b/GraceLog/Source/Presentation/SearchScene/Coordinator/SearchCoordinator.swift
@@ -32,7 +32,9 @@ extension SearchCoordinator {
     }
     
     func showCommunityViewController(id: Int) {
-        print("선택한 커뮤니티 아이디: \(id)")
+        let coordinator = CommunityGroupCoordinator(navigationController: self.navigationController, id: id)
+        childCoordinators.append(coordinator)
+        coordinator.start()
     }
     
     func showCreateCommunityViewController() {

--- a/GraceLog/Source/Presentation/SearchScene/DataSource/CommunityGroupSection.swift
+++ b/GraceLog/Source/Presentation/SearchScene/DataSource/CommunityGroupSection.swift
@@ -1,0 +1,32 @@
+//
+//  CommunityGroupSection.swift
+//  GraceLog
+//
+//  Created by 이건준 on 1/1/26.
+//
+
+import RxDataSources
+
+struct CommunityGroupSection {
+    let date: Date
+    var items: [CommunityDiaryItem]
+    
+    init(date: Date, items: [CommunityDiaryItem]) {
+        self.date = date
+        self.items = items
+    }
+}
+
+extension CommunityGroupSection: AnimatableSectionModelType {
+    typealias Item = CommunityDiaryItem
+    typealias Identity = String
+    
+    var identity: String {
+        DateFormatterFactory.dateWithShortKorean.string(from: date)
+    }
+    
+    init(original: CommunityGroupSection, items: [CommunityDiaryItem]) {
+        self = original
+        self.items = items
+    }
+}

--- a/GraceLog/Source/Presentation/SearchScene/Reactor/Community/CommunityGroupReactor.swift
+++ b/GraceLog/Source/Presentation/SearchScene/Reactor/Community/CommunityGroupReactor.swift
@@ -9,36 +9,147 @@ import ReactorKit
 
 final class CommunityGroupReactor: Reactor {
     private let coordinator: CommunityGroupCoordinator
-    private let usecase: CommunityGroupUseCase
+    private let diaryDetailUseCase: DiaryDetailsUseCase
+    
     let initialState: State
     
-    init(usecase: CommunityGroupUseCase, coordinator: CommunityGroupCoordinator) {
-        self.usecase = usecase
+    init(diaryDetailUseCase: DiaryDetailsUseCase, coordinator: CommunityGroupCoordinator) {
+        self.diaryDetailUseCase = diaryDetailUseCase
         self.coordinator = coordinator
-        self.initialState = .init()
+        self.initialState = .init(editedDateList: [], sectionedDiaryList: [])
     }
     
     enum Action {
         case didTapBackButton
+        case fetchDiaryList(Date)
+        case didTapDiaryDetail(Int)
+        case didTapLikeButton(Int)
+        case didTapCommentButton(Int)
     }
     
     enum Mutation {
-
+        case setDiaryList([CommunityGroupSection])
+        case setEditedDateList([Date])
+        case setLikedStateResult((Bool, Int))
+        case setUnLikedStateResult((Bool, Int))
     }
     
     struct State {
-
+        @Pulse var editedDateList: [Date]
+        @Pulse var sectionedDiaryList: [CommunityGroupSection]
+        @Pulse var isSuccessLikeDiary: (Bool, Int)?
+        @Pulse var isSuccessUnlikeResult: (Bool, Int)?
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .didTapBackButton:
             coordinator.popViewController()
+        case let .fetchDiaryList(selectedDate):
+            let calendar = Calendar.current
+            let year = calendar.component(.year, from: selectedDate)
+            let month = calendar.component(.month, from: selectedDate)
+            let (startDate, endDate) = DateFormatterFactory.getMonthDateRange(year: year, month: month)
+            diaryDetailUseCase.fetchDateRangeDiaryList(startDate: startDate, endDate: endDate)
+        case .didTapLikeButton(let diaryID):
+            guard let selectedDiary = currentState.sectionedDiaryList.flatMap { $0.items }.first(where: { $0.id == diaryID }) else { return .empty() }
+            if selectedDiary.isLiked {
+                diaryDetailUseCase.unlikeDiary(id: diaryID)
+            } else {
+                diaryDetailUseCase.likeDiary(id: diaryID)
+            }
+        case let .didTapCommentButton(diaryID):
+            coordinator.showCommentBottomSheet(diaryID: diaryID)
+        case .didTapDiaryDetail(_):
+            return .empty()
         }
         return .empty()
     }
     
-    func reduce(state: State, mutation: Mutation) -> State {
+    func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
+        let diaryMutation = diaryDetailUseCase.dateRangeDiaries.share(replay: 1)
+        let editedDiaryMutation = diaryMutation.map { $0.compactMap { $0.createdAt } }
+            .map { Mutation.setEditedDateList($0) }
+        let fetchedDiaryMutation = diaryMutation
+            .map { diaries -> [CommunityGroupSection] in
+                let datedDiaries: [(date: Date, diary: DiaryDetails)] = diaries.compactMap { diary in
+                    guard let date = diary.createdAt else { return nil }
+                    return (date, diary)
+                }
+                let calendar = Calendar.current
+                let grouped = Dictionary(grouping: datedDiaries) { item in
+                    calendar.startOfDay(for: item.date) 
+                }
+
+                let sections: [CommunityGroupSection] = grouped.map { (dayStart, items) in
+                    CommunityGroupSection(
+                        date: dayStart,
+                        items: items.map { (_, diary) in
+                            CommunityDiaryItem(from: .init(
+                                id: diary.diaryId,
+                                title: diary.title,
+                                content: diary.description,
+                                editedDate: diary.createdAt,
+                                isLiked: !diary.isHideLike,
+                                likeCount: diary.likeCount,
+                                commentCount: diary.commentCount,
+                                username: diary.user.name,
+                                profileImageURL: diary.user.profileImageURL,
+                                diaryImageURL: diary.imageURLs.first ?? nil,
+                                isCurrentUser: diary.likeByMe
+                            ))
+                        }
+                    )
+                }
+                .sorted { $0.date > $1.date }
+
+                return sections
+            }
+            .map { Mutation.setDiaryList($0) }
         
+        let diaryLikedToggleResult = diaryDetailUseCase.likeDiaryResult.map { Mutation.setLikedStateResult(($0.0, $0.1)) }
+        let diaryUnLikedToggleResult = diaryDetailUseCase.unlikeDiaryResult.map { Mutation.setUnLikedStateResult($0) }
+        return Observable.merge(mutation, fetchedDiaryMutation, editedDiaryMutation, diaryLikedToggleResult, diaryUnLikedToggleResult)
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        
+        switch mutation {
+        case .setDiaryList(let model):
+            newState.sectionedDiaryList = model
+        case .setEditedDateList(let model):
+            newState.editedDateList = model
+        case let .setLikedStateResult(result):
+            let (isSuccess, diaryID) = result
+            guard isSuccess else { return newState }
+            newState.sectionedDiaryList = newState.sectionedDiaryList.map { section in
+                var section = section
+                section.items = section.items.map { item in
+                    guard item.id == diaryID else { return item }
+                    var newItem = item
+                    newItem.isLiked = true
+                    newItem.likeCount = max(0, item.likeCount + 1)
+                    return newItem
+                }
+                return section
+            }
+        case let .setUnLikedStateResult(result):
+            let (isSuccess, diaryID) = result
+            guard isSuccess else { return newState }
+            newState.sectionedDiaryList = newState.sectionedDiaryList.map { section in
+                var section = section
+                section.items = section.items.map { item in
+                    guard item.id == diaryID else { return item }
+                    var newItem = item
+                    newItem.isLiked = false
+                    newItem.likeCount = max(0, item.likeCount - 1)
+                    return newItem
+                }
+                return section
+            }
+        }
+        
+        return newState
     }
 }

--- a/GraceLog/Source/Presentation/SearchScene/Reactor/Community/CommunityGroupReactor.swift
+++ b/GraceLog/Source/Presentation/SearchScene/Reactor/Community/CommunityGroupReactor.swift
@@ -1,0 +1,40 @@
+//
+//  CommunityGroupReactor.swift
+//  GraceLog
+//
+//  Created by 이건준 on 12/29/25.
+//
+
+import ReactorKit
+
+final class CommunityGroupReactor: Reactor {
+    private let coordinator: CommunityGroupCoordinator
+    private let usecase: CommunityGroupUseCase
+    let initialState: State
+    
+    init(usecase: CommunityGroupUseCase, coordinator: CommunityGroupCoordinator) {
+        self.usecase = usecase
+        self.coordinator = coordinator
+        self.initialState = .init()
+    }
+    
+    enum Action {
+
+    }
+    
+    enum Mutation {
+
+    }
+    
+    struct State {
+
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        return .empty()
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        
+    }
+}

--- a/GraceLog/Source/Presentation/SearchScene/Reactor/Community/CommunityGroupReactor.swift
+++ b/GraceLog/Source/Presentation/SearchScene/Reactor/Community/CommunityGroupReactor.swift
@@ -8,33 +8,41 @@
 import ReactorKit
 
 final class CommunityGroupReactor: Reactor {
-    private let coordinator: CommunityGroupCoordinator
-    private let diaryDetailUseCase: DiaryDetailsUseCase
+    var coordinator: CommunityGroupCoordinator?
+    private let usecase: CommunityGroupUseCase
     
     let initialState: State
     
-    init(diaryDetailUseCase: DiaryDetailsUseCase, coordinator: CommunityGroupCoordinator) {
-        self.diaryDetailUseCase = diaryDetailUseCase
-        self.coordinator = coordinator
-        self.initialState = .init(editedDateList: [], sectionedDiaryList: [])
+    init(
+        usecase: CommunityGroupUseCase
+    ) {
+        self.usecase = usecase
+        self.initialState = .init(
+            editedDateList: [],
+            sectionedDiaryList: []
+        )
+        
+        usecase.fetchLatestCommunityDiaryExistenceDate()
     }
     
     enum Action {
-        case didTapBackButton
+        case fetchEditedDateList(Date)
         case fetchDiaryList(Date)
-        case didTapDiaryDetail(Int)
+        case loadNextPage
+        case didTapBackButton
+        case didTapDiaryDetail(Int, Int?, Int?)
         case didTapLikeButton(Int)
         case didTapCommentButton(Int)
     }
     
     enum Mutation {
+        case setLastestPostDate(Date)
         case setDiaryList([CommunityGroupSection])
-        case setEditedDateList([Date])
-        case setLikedStateResult((Bool, Int))
-        case setUnLikedStateResult((Bool, Int))
+        case setEditedDateList([DiaryExistenceDate])
     }
     
     struct State {
+        @Pulse var latestPostDate: Date?
         @Pulse var editedDateList: [Date]
         @Pulse var sectionedDiaryList: [CommunityGroupSection]
         @Pulse var isSuccessLikeDiary: (Bool, Int)?
@@ -43,113 +51,93 @@ final class CommunityGroupReactor: Reactor {
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
+        case .fetchEditedDateList(let date):
+            usecase.fetchCommunityDiaryExistenceDates(date: date)
+        case .fetchDiaryList(let selectedDate):
+            usecase.fetchCommunityDiaryList(date: DateFormatterFactory.toDateOnlyString(from: selectedDate))
+        case .loadNextPage:
+            usecase.loadNextPage()
         case .didTapBackButton:
-            coordinator.popViewController()
-        case let .fetchDiaryList(selectedDate):
-            let calendar = Calendar.current
-            let year = calendar.component(.year, from: selectedDate)
-            let month = calendar.component(.month, from: selectedDate)
-            let (startDate, endDate) = DateFormatterFactory.getMonthDateRange(year: year, month: month)
-            diaryDetailUseCase.fetchDateRangeDiaryList(startDate: startDate, endDate: endDate)
+            coordinator?.popViewController()
         case .didTapLikeButton(let diaryID):
-            guard let selectedDiary = currentState.sectionedDiaryList.flatMap { $0.items }.first(where: { $0.id == diaryID }) else { return .empty() }
-            if selectedDiary.isLiked {
-                diaryDetailUseCase.unlikeDiary(id: diaryID)
-            } else {
-                diaryDetailUseCase.likeDiary(id: diaryID)
-            }
+            usecase.toggleDiaryLike(id: diaryID)
         case let .didTapCommentButton(diaryID):
-            coordinator.showCommentBottomSheet(diaryID: diaryID)
-        case .didTapDiaryDetail(_):
-            return .empty()
+            coordinator?.showCommentBottomSheet(diaryID: diaryID)
+        case .didTapDiaryDetail(let diaryId, let communityId, let memberId):
+            coordinator?.showDiaryDetail(
+                diaryId: diaryId,
+                communityId: communityId,
+                memberId: memberId
+            )
         }
         return .empty()
     }
+
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        
+        switch mutation {
+        case .setLastestPostDate(let date):
+            newState.latestPostDate = date
+        case .setDiaryList(let model):
+            newState.sectionedDiaryList = model
+        case .setEditedDateList(let dates):
+            newState.editedDateList = dates.map { $0.date }
+        }
+        return newState
+    }
     
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
-        let diaryMutation = diaryDetailUseCase.dateRangeDiaries.share(replay: 1)
-        let editedDiaryMutation = diaryMutation.map { $0.compactMap { $0.createdAt } }
+        let latestPostDateMutation = usecase.latestCommunityDiaryExistenceDate
+            .compactMap { $0 }
+            .map { Mutation.setLastestPostDate($0) }
+        
+        let editedDateListMutation = usecase.diaryExistenceDates
             .map { Mutation.setEditedDateList($0) }
-        let fetchedDiaryMutation = diaryMutation
+        
+        let diaryListMutation = usecase.communityDiaryList
             .map { diaries -> [CommunityGroupSection] in
-                let datedDiaries: [(date: Date, diary: DiaryDetails)] = diaries.compactMap { diary in
-                    guard let date = diary.createdAt else { return nil }
+                let datedDiaries: [(date: Date, diary: CommunityDiaryPreview)] = diaries.compactMap { diary in
+                    guard let date = diary.editedDate else { return nil }
                     return (date, diary)
                 }
                 let calendar = Calendar.current
                 let grouped = Dictionary(grouping: datedDiaries) { item in
-                    calendar.startOfDay(for: item.date) 
+                    calendar.startOfDay(for: item.date)
                 }
-
+                
                 let sections: [CommunityGroupSection] = grouped.map { (dayStart, items) in
                     CommunityGroupSection(
                         date: dayStart,
                         items: items.map { (_, diary) in
                             CommunityDiaryItem(from: .init(
-                                id: diary.diaryId,
+                                id: diary.id,
                                 title: diary.title,
-                                content: diary.description,
-                                editedDate: diary.createdAt,
-                                isLiked: !diary.isHideLike,
+                                content: diary.content,
+                                editedDate: diary.editedDate,
+                                isLiked: diary.isLiked,
                                 likeCount: diary.likeCount,
                                 commentCount: diary.commentCount,
-                                username: diary.user.name,
-                                profileImageURL: diary.user.profileImageURL,
-                                diaryImageURL: diary.imageURLs.first ?? nil,
-                                isCurrentUser: diary.likeByMe
+                                userId: diary.userId,
+                                username: diary.username,
+                                profileImageURL: diary.profileImageURL,
+                                diaryImageURL: diary.diaryImageURL,
+                                isCurrentUser: diary.isCurrentUser,
+                                communityId: diary.communityId
                             ))
                         }
                     )
-                }
-                .sorted { $0.date > $1.date }
-
+                }.sorted { $0.date > $1.date }
+                
                 return sections
             }
             .map { Mutation.setDiaryList($0) }
         
-        let diaryLikedToggleResult = diaryDetailUseCase.likeDiaryResult.map { Mutation.setLikedStateResult(($0.0, $0.1)) }
-        let diaryUnLikedToggleResult = diaryDetailUseCase.unlikeDiaryResult.map { Mutation.setUnLikedStateResult($0) }
-        return Observable.merge(mutation, fetchedDiaryMutation, editedDiaryMutation, diaryLikedToggleResult, diaryUnLikedToggleResult)
-    }
-    
-    func reduce(state: State, mutation: Mutation) -> State {
-        var newState = state
-        
-        switch mutation {
-        case .setDiaryList(let model):
-            newState.sectionedDiaryList = model
-        case .setEditedDateList(let model):
-            newState.editedDateList = model
-        case let .setLikedStateResult(result):
-            let (isSuccess, diaryID) = result
-            guard isSuccess else { return newState }
-            newState.sectionedDiaryList = newState.sectionedDiaryList.map { section in
-                var section = section
-                section.items = section.items.map { item in
-                    guard item.id == diaryID else { return item }
-                    var newItem = item
-                    newItem.isLiked = true
-                    newItem.likeCount = max(0, item.likeCount + 1)
-                    return newItem
-                }
-                return section
-            }
-        case let .setUnLikedStateResult(result):
-            let (isSuccess, diaryID) = result
-            guard isSuccess else { return newState }
-            newState.sectionedDiaryList = newState.sectionedDiaryList.map { section in
-                var section = section
-                section.items = section.items.map { item in
-                    guard item.id == diaryID else { return item }
-                    var newItem = item
-                    newItem.isLiked = false
-                    newItem.likeCount = max(0, item.likeCount - 1)
-                    return newItem
-                }
-                return section
-            }
-        }
-        
-        return newState
+        return Observable.merge(
+            mutation,
+            latestPostDateMutation,
+            editedDateListMutation,
+            diaryListMutation
+        )
     }
 }

--- a/GraceLog/Source/Presentation/SearchScene/Reactor/Community/CommunityGroupReactor.swift
+++ b/GraceLog/Source/Presentation/SearchScene/Reactor/Community/CommunityGroupReactor.swift
@@ -19,7 +19,7 @@ final class CommunityGroupReactor: Reactor {
     }
     
     enum Action {
-
+        case didTapBackButton
     }
     
     enum Mutation {
@@ -31,6 +31,10 @@ final class CommunityGroupReactor: Reactor {
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .didTapBackButton:
+            coordinator.popViewController()
+        }
         return .empty()
     }
     

--- a/GraceLog/Source/Presentation/SearchScene/Reactor/Community/CreateCommunityReactor.swift
+++ b/GraceLog/Source/Presentation/SearchScene/Reactor/Community/CreateCommunityReactor.swift
@@ -31,18 +31,21 @@ final class CreateCommunityReactor: Reactor {
         case editTitle(String)
         case didTapCreateButton
         case didTapBackButton
+        case executeCreateCommunity
     }
     
     enum Mutation {
         case setImages([DiaryImage])
         case setTitle(String)
         case setErrorMessage(String?)
+        case setCreateCommunityResult(Bool)
     }
     
     struct State {
         @Pulse var images: [DiaryImage]
         var editedTitle: String
         var errorMessage: String?
+        @Pulse var isSuccessCreateCommunity: Bool?
     }
     
     // MARK: - Mutate
@@ -58,27 +61,26 @@ final class CreateCommunityReactor: Reactor {
             }
             
             return .just(.setImages(uploadImages))
-            
         case .deleteImage(let index):
             var updatedImages = currentState.images
             if index < updatedImages.count {
                 updatedImages.remove(at: index)
             }
-            return .just(.setImages(updatedImages))
             
+            return .just(.setImages(updatedImages))
         case let .editTitle(title):
             return .just(.setTitle(title))
-            
         case .didTapCreateButton:
             usecase.createCommunity(
                 title: currentState.editedTitle,
                 images: currentState.images
             )
-            return .empty()
         case .didTapBackButton:
             coordinator?.popViewController()
-            return .empty()
+        case .executeCreateCommunity:
+            coordinator?.createCommunityEvent()
         }
+        return .empty()
     }
     
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
@@ -107,7 +109,21 @@ final class CreateCommunityReactor: Reactor {
                 }
             }
         
-        return Observable.merge(mutation, resultMutation)
+        let createResultMutation = usecase.createCommunityResult
+            .map { result -> Mutation in
+                switch result {
+                case .success:
+                    return .setCreateCommunityResult(true)
+                case .failure:
+                    return .setCreateCommunityResult(false)
+                }
+            }
+        
+        return Observable.merge(
+            mutation,
+            resultMutation,
+            createResultMutation
+        )
     }
     
     func reduce(state: State, mutation: Mutation) -> State {
@@ -116,12 +132,12 @@ final class CreateCommunityReactor: Reactor {
         switch mutation {
         case .setImages(let images):
             newState.images = images
-            
         case .setTitle(let title):
             newState.editedTitle = title
-            
         case .setErrorMessage(let message):
             newState.errorMessage = message
+        case .setCreateCommunityResult(let isSuccess):
+            newState.isSuccessCreateCommunity = isSuccess
         }
         
         return newState

--- a/GraceLog/Source/Presentation/SearchScene/Reactor/Community/CreateCommunityReactor.swift
+++ b/GraceLog/Source/Presentation/SearchScene/Reactor/Community/CreateCommunityReactor.swift
@@ -10,15 +10,14 @@ import ReactorKit
 final class CreateCommunityReactor: Reactor {
     let initialState: State
     private let usecase: CreateCommunityUseCase
-    private let coordinator: CreateCommunityCoordinator
+    var coordinator: CreateCommunityCoordinator?
     
     private var maxCommunityImageCount: Int {
         usecase.maxImageCount
     }
     
-    init(usecase: CreateCommunityUseCase, coordinator: CreateCommunityCoordinator) {
+    init(usecase: CreateCommunityUseCase) {
         self.usecase = usecase
-        self.coordinator = coordinator
         self.initialState = State(
             images: [],
             editedTitle: "",
@@ -77,7 +76,7 @@ final class CreateCommunityReactor: Reactor {
             )
             return .empty()
         case .didTapBackButton:
-            coordinator.popViewController()
+            coordinator?.popViewController()
             return .empty()
         }
     }

--- a/GraceLog/Source/Presentation/SearchScene/Reactor/SearchViewReactor.swift
+++ b/GraceLog/Source/Presentation/SearchScene/Reactor/SearchViewReactor.swift
@@ -64,8 +64,9 @@ final class SearchViewReactor: Reactor {
             let id = currentState.profiles[indexPath.row].id
             coordinator.showProfileViewController(id: id)
         case let .didTapCommunity(indexPath):
-            let id = currentState.communities[indexPath.row].id
-            coordinator.showCommunityViewController(id: id)
+            let communityId = currentState.communities[indexPath.row].id
+//            guard let memberId = UserManager.shared.id else { return .empty() }
+            coordinator.showCommunityViewController(communityId: communityId, memberId: 0)
         case let .didTapChattingRoom(indexPath):
             let id = currentState.rooms[indexPath.row].id
             coordinator.showCommunityChattingViewController(id: id)

--- a/GraceLog/Source/Presentation/SearchScene/ViewController/Community/CommunityGroupViewController.swift
+++ b/GraceLog/Source/Presentation/SearchScene/ViewController/Community/CommunityGroupViewController.swift
@@ -1,0 +1,15 @@
+//
+//  CommunityGroupViewController.swift
+//  GraceLog
+//
+//  Created by 이건준 on 12/29/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class CommunityGroupViewController: GraceLogBaseViewController<CommunityGroupReactor> {
+    
+}

--- a/GraceLog/Source/Presentation/SearchScene/ViewController/Community/CommunityGroupViewController.swift
+++ b/GraceLog/Source/Presentation/SearchScene/ViewController/Community/CommunityGroupViewController.swift
@@ -11,5 +11,22 @@ import SnapKit
 import Then
 
 final class CommunityGroupViewController: GraceLogBaseViewController<CommunityGroupReactor> {
+    private let backButton = UIButton().then {
+        $0.setImage(UIImage(named: "chevron_left_theme"), for: .normal)
+    }
     
+    override func setupStyles() {
+        super.setupStyles()
+        navigationBar.addLeftItem(backButton)
+        navigationBar.setupTitleLabel(text: "공동체")
+    }
+    override func bind(reactor: CommunityGroupReactor) {
+        /// Action
+        backButton.rx.tap
+            .map { Reactor.Action.didTapBackButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+    }
+}
 }

--- a/GraceLog/Source/Presentation/SearchScene/ViewController/Community/CommunityGroupViewController.swift
+++ b/GraceLog/Source/Presentation/SearchScene/ViewController/Community/CommunityGroupViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import FSCalendar
 import RxSwift
+import ReactorKit
 import RxDataSources
 import SnapKit
 import Then
@@ -93,7 +94,7 @@ final class CommunityGroupViewController: GraceLogBaseViewController<CommunityGr
     
     override func setupConstraints() {
         super.setupConstraints()
-
+        
         scrollView.snp.makeConstraints {
             $0.directionalEdges.equalToSuperview()
         }
@@ -110,7 +111,23 @@ final class CommunityGroupViewController: GraceLogBaseViewController<CommunityGr
     }
     
     override func bind(reactor: CommunityGroupReactor) {
-        reactor.action.onNext(.fetchDiaryList(Date()))
+        let latestPostDate = reactor.pulse(\.$latestPostDate)
+            .compactMap { $0 }
+            .share()
+        
+        latestPostDate
+            .subscribe(with: self) { owner, date in
+                reactor.action.onNext(.fetchEditedDateList(date))
+                reactor.action.onNext(.fetchDiaryList(date))
+            }
+            .disposed(by: disposeBag)
+        
+        latestPostDate
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, date in
+                owner.calendarView.select(date)
+            }
+            .disposed(by: disposeBag)
         
         backButton.rx.tap
             .map { Reactor.Action.didTapBackButton }
@@ -125,12 +142,13 @@ final class CommunityGroupViewController: GraceLogBaseViewController<CommunityGr
         
         reactor.pulse(\.$editedDateList)
             .asDriver(onErrorJustReturn: [])
-            .drive(with: self) { owner, editedDateList in
+            .drive(with: self) { owner, _ in
                 owner.calendarView.reloadData()
             }
             .disposed(by: disposeBag)
         
         bindCommunityDiaryTableView(reactor: reactor)
+        bindScrollViewPagination(reactor: reactor)
     }
     
     private func bindCommunityDiaryTableView(reactor: CommunityGroupReactor) {
@@ -178,7 +196,11 @@ final class CommunityGroupViewController: GraceLogBaseViewController<CommunityGr
                             return
                         }
                         
-                        reactor.action.onNext(.didTapDiaryDetail(selectedItem.id))
+                        reactor.action.onNext(.didTapDiaryDetail(
+                            selectedItem.id,
+                            selectedItem.communityId,
+                            selectedItem.userId
+                        ))
                     })
                     .disposed(by: cell.disposeBag)
                 
@@ -210,6 +232,21 @@ final class CommunityGroupViewController: GraceLogBaseViewController<CommunityGr
         reactor.pulse(\.$sectionedDiaryList)
             .asDriver(onErrorJustReturn: [])
             .drive(communityDiaryListView.diaryTableView.rx.items(dataSource: diaryDataSource))
+            .disposed(by: disposeBag)
+    }
+    
+    private func bindScrollViewPagination(reactor: CommunityGroupReactor) {
+        scrollView.rx.didEndDragging
+            .filter { [weak self] _ in
+                guard let self = self else { return false }
+                let offsetY = self.scrollView.contentOffset.y
+                let contentHeight = self.scrollView.contentSize.height
+                let height = self.scrollView.frame.height
+                
+                return offsetY > contentHeight - height
+            }
+            .map { _ in CommunityGroupReactor.Action.loadNextPage }
+            .bind(to: reactor.action)
             .disposed(by: disposeBag)
     }
 }
@@ -245,7 +282,7 @@ extension CommunityGroupViewController: FSCalendarDelegate, FSCalendarDataSource
         config?.title = DateFormatterFactory.toYearMonthString(from: nextMonthDate)
         calendarButton.configuration = config
         
-        reactor?.action.onNext(.fetchDiaryList(nextMonthDate))
+        reactor?.action.onNext(.fetchEditedDateList(nextMonthDate))
     }
     
     /// 감사일기가 작성된 날짜 마커
@@ -254,7 +291,7 @@ extension CommunityGroupViewController: FSCalendarDelegate, FSCalendarDataSource
         let hasEvent = currentEditedDateList.contains(where: { return Calendar.current.isDate($0, inSameDayAs: date) })
         return hasEvent ? 1 : 0
     }
-
+    
     /// 날짜 선택 가능 여부 결정
     func calendar(_ calendar: FSCalendar, shouldSelect date: Date, at monthPosition: FSCalendarMonthPosition) -> Bool {
         guard let currentEditedDateList = reactor?.currentState.editedDateList else { return false }

--- a/GraceLog/Source/Presentation/SearchScene/ViewController/Community/CommunityGroupViewController.swift
+++ b/GraceLog/Source/Presentation/SearchScene/ViewController/Community/CommunityGroupViewController.swift
@@ -7,26 +7,262 @@
 
 import UIKit
 
+import FSCalendar
+import RxSwift
+import RxDataSources
 import SnapKit
 import Then
 
 final class CommunityGroupViewController: GraceLogBaseViewController<CommunityGroupReactor> {
+    private var diaryDataSource: RxTableViewSectionedAnimatedDataSource<CommunityGroupSection>!
+    
     private let backButton = UIButton().then {
         $0.setImage(UIImage(named: "chevron_left_theme"), for: .normal)
     }
+    
+    private let scrollView = UIScrollView().then {
+        $0.showsVerticalScrollIndicator = true
+        $0.showsHorizontalScrollIndicator = false
+        $0.alwaysBounceVertical = true
+        $0.backgroundColor = GLColor.backgroundMain.color
+    }
+    
+    private let containerStackView = UIStackView().then {
+        $0.backgroundColor = .clear
+        $0.axis = .vertical
+        $0.distribution = .fill
+        $0.alignment = .fill
+        $0.spacing = 20
+        $0.isLayoutMarginsRelativeArrangement = true
+        $0.layoutMargins = .init(top: 20, left: 20, bottom: 20, right: 20)
+    }
+    
+    private lazy var calendarButton = UIButton().then {
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(named: "chevron_down")?.withRenderingMode(.alwaysTemplate)
+        config.title = DateFormatterFactory.toYearMonthString(from: calendarView.currentPage)
+        config.baseForegroundColor = GLColor.textBasic.color
+        config.imagePlacement = .trailing
+        config.imagePadding = 7
+        config.contentInsets = .zero
+        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var outgoing = incoming
+            outgoing.font = GLFont.regular24.font
+            return outgoing
+        }
+        $0.configuration = config
+        $0.tintColor = .white
+        $0.contentHorizontalAlignment = .leading
+    }
+    
+    private lazy var calendarView = FSCalendar().then {
+        $0.tintColor = .white
+        $0.scrollDirection = .horizontal
+        $0.scope = .week
+        $0.today = nil
+        $0.locale = Locale(identifier: "ko_KR")
+        $0.headerHeight = 0
+        $0.appearance.weekdayFont = GLFont.regular12.font
+        $0.appearance.weekdayTextColor = GLColor.textBasic.color
+        $0.appearance.titleFont = GLFont.regular18.font
+        $0.appearance.titleDefaultColor = GLColor.textBasic.color
+        $0.appearance.todaySelectionColor = GLColor.textAccent.color
+        $0.appearance.selectionColor = GLColor.textAccent.color
+        $0.appearance.titleTodayColor = UIColor.white
+        $0.appearance.eventDefaultColor = GLColor.textAccent.color
+        $0.appearance.eventSelectionColor = .clear
+        $0.delegate = self
+        $0.dataSource = self
+    }
+    
+    private let communityDiaryListView = HomeCommunityDiaryListView()
     
     override func setupStyles() {
         super.setupStyles()
         navigationBar.addLeftItem(backButton)
         navigationBar.setupTitleLabel(text: "공동체")
     }
+    
+    override func setupLayouts() {
+        super.setupLayouts()
+        contentView.addSubview(scrollView)
+        
+        scrollView.addSubview(containerStackView)
+        [calendarButton, calendarView, communityDiaryListView].forEach { containerStackView.addArrangedSubview($0) }
+    }
+    
+    override func setupConstraints() {
+        super.setupConstraints()
+
+        scrollView.snp.makeConstraints {
+            $0.directionalEdges.equalToSuperview()
+        }
+        
+        containerStackView.snp.makeConstraints {
+            $0.directionalEdges.width.equalToSuperview()
+        }
+        
+        containerStackView.setCustomSpacing(5, after: calendarView)
+        
+        calendarView.snp.makeConstraints {
+            $0.height.equalTo(250)
+        }
+    }
+    
     override func bind(reactor: CommunityGroupReactor) {
-        /// Action
+        reactor.action.onNext(.fetchDiaryList(Date()))
+        
         backButton.rx.tap
             .map { Reactor.Action.didTapBackButton }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        calendarButton.rx.tap
+            .bind(with: self) { owner, _ in
+                owner.calendarView.scope = owner.calendarView.scope == .month ? .week : .month
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$editedDateList)
+            .asDriver(onErrorJustReturn: [])
+            .drive(with: self) { owner, editedDateList in
+                owner.calendarView.reloadData()
+            }
+            .disposed(by: disposeBag)
+        
+        bindCommunityDiaryTableView(reactor: reactor)
+    }
+    
+    private func bindCommunityDiaryTableView(reactor: CommunityGroupReactor) {
+        diaryDataSource = RxTableViewSectionedAnimatedDataSource<CommunityGroupSection>(
+            animationConfiguration: .init(
+                insertAnimation: .none,
+                reloadAnimation: .none,
+                deleteAnimation: .none
+            ),
+            configureCell: { _, tableView, indexPath, item in
+                let cell = tableView.dequeueReusableCell(withIdentifier: HomeCommunityDiaryTableViewCell.reuseIdentifier, for: indexPath) as! HomeCommunityDiaryTableViewCell
+                
+                cell.updateUI(
+                    username: item.username,
+                    title: item.title,
+                    content: item.content,
+                    likeCount: item.likeCount,
+                    commentCount: item.commentCount,
+                    isLiked: item.isLiked,
+                    isCurrentUser: item.isCurrentUser,
+                    profileImageURL: item.profileImageURL,
+                    cardImageURL: item.cardImageURL
+                )
+                
+                cell.profileImageView.rx.tapGesture().when(.recognized)
+                    .asDriver(onErrorDriveWith: .empty())
+                    .drive(onNext: { [weak self] _ in
+                        guard let self,
+                              let indexPath = self.communityDiaryListView.diaryTableView.indexPath(for: cell),
+                              let selectedItem = try? self.communityDiaryListView.diaryTableView.rx.model(at: indexPath) as CommunityDiaryItem else {
+                            return
+                        }
+                        
+                        // TODO: - 선택한 유저 정보로 이동
+                        print("선택된 유저 이름: \(selectedItem)")
+                    })
+                    .disposed(by: cell.disposeBag)
+                
+                cell.cardImageView.rx.tapGesture().when(.recognized)
+                    .asDriver(onErrorDriveWith: .empty())
+                    .drive(onNext: { [weak self] _ in
+                        guard let self,
+                              let indexPath = self.communityDiaryListView.diaryTableView.indexPath(for: cell),
+                              let selectedItem = try? self.communityDiaryListView.diaryTableView.rx.model(at: indexPath) as CommunityDiaryItem else {
+                            return
+                        }
+                        
+                        reactor.action.onNext(.didTapDiaryDetail(selectedItem.id))
+                    })
+                    .disposed(by: cell.disposeBag)
+                
+                cell.likeButton.rx.tap
+                    .do(onNext: { _ in
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    })
+                    .throttle(.milliseconds(500), scheduler: ConcurrentDispatchQueueScheduler.init(qos: .default))
+                    .map { CommunityGroupReactor.Action.didTapLikeButton(item.id)}
+                    .bind(to: reactor.action)
+                    .disposed(by: cell.disposeBag)
+                
+                cell.commentButton.rx.tap
+                    .asDriver()
+                    .drive(onNext: { [weak self] _ in
+                        guard let self,
+                              let indexPath = self.communityDiaryListView.diaryTableView.indexPath(for: cell),
+                              let selectedItem = try? self.communityDiaryListView.diaryTableView.rx.model(at: indexPath) as CommunityDiaryItem else {
+                            return
+                        }
+                        print("선택한 댓글 아이템 \(selectedItem)")
+                    })
+                    .disposed(by: cell.disposeBag)
+                
+                return cell
+            }
+        )
+        
+        reactor.pulse(\.$sectionedDiaryList)
+            .asDriver(onErrorJustReturn: [])
+            .drive(communityDiaryListView.diaryTableView.rx.items(dataSource: diaryDataSource))
+            .disposed(by: disposeBag)
     }
 }
+
+extension CommunityGroupViewController: FSCalendarDelegate, FSCalendarDataSource, UIScrollViewDelegate {
+    func calendar(_ calendar: FSCalendar, boundingRectWillChange bounds: CGRect, animated: Bool) {
+        calendarView.snp.updateConstraints {
+            $0.height.equalTo(bounds.height)
+        }
+        
+        UIView.animate(
+            withDuration: 0.3,
+            delay: 0.03,
+            options: [.curveEaseInOut]
+        ) { self.view.layoutIfNeeded() }
+        
+        var config = calendarButton.configuration
+        config?.image = UIImage(named: calendar.scope == .month ? "chevron_up" : "chevron_down")?.withRenderingMode(.alwaysTemplate)
+        calendarButton.configuration = config
+    }
+    
+    /// 캘린더 뷰의 년도 및 월이 바뀌는 경우
+    func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
+        let currentPage = calendar.currentPage
+        
+        let nextMonthDate = Calendar.current.date(
+            byAdding: .day,
+            value: 1,
+            to: currentPage
+        ) ?? currentPage
+        
+        var config = calendarButton.configuration
+        config?.title = DateFormatterFactory.toYearMonthString(from: nextMonthDate)
+        calendarButton.configuration = config
+        
+        reactor?.action.onNext(.fetchDiaryList(nextMonthDate))
+    }
+    
+    /// 감사일기가 작성된 날짜 마커
+    func calendar(_ calendar: FSCalendar, numberOfEventsFor date: Date) -> Int {
+        guard let currentEditedDateList = reactor?.currentState.editedDateList else { return 0 }
+        let hasEvent = currentEditedDateList.contains(where: { return Calendar.current.isDate($0, inSameDayAs: date) })
+        return hasEvent ? 1 : 0
+    }
+
+    /// 날짜 선택 가능 여부 결정
+    func calendar(_ calendar: FSCalendar, shouldSelect date: Date, at monthPosition: FSCalendarMonthPosition) -> Bool {
+        guard let currentEditedDateList = reactor?.currentState.editedDateList else { return false }
+        let hasEvent = currentEditedDateList.contains(where: { return Calendar.current.isDate($0, inSameDayAs: date) })
+        return hasEvent
+    }
+    
+    func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
+        reactor?.action.onNext(.fetchDiaryList(date))
+    }
 }

--- a/GraceLog/Source/Presentation/SearchScene/ViewController/Community/CreateCommunityViewController.swift
+++ b/GraceLog/Source/Presentation/SearchScene/ViewController/Community/CreateCommunityViewController.swift
@@ -112,11 +112,19 @@ final class CreateCommunityViewController: GraceLogBaseViewController<CreateComm
                 owner.showToast(message)
             }
             .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$isSuccessCreateCommunity)
+            .compactMap { $0 }
+            .bind(with: self) { owner, isSuccess in
+                if isSuccess {
+                    reactor.action.onNext(.executeCreateCommunity)
+                }
+            }
+            .disposed(by: disposeBag)
     }
 }
 
 // MARK: - Diary Bindings
-
 extension CreateCommunityViewController {
     private func bindDiaryImageCollectionView(reactor: CreateCommunityReactor) {
         let imageDataSource = RxCollectionViewSectionedAnimatedDataSource<DiaryImageSection>(

--- a/GraceLog/Source/Presentation/SearchScene/ViewController/SearchViewController.swift
+++ b/GraceLog/Source/Presentation/SearchScene/ViewController/SearchViewController.swift
@@ -123,6 +123,14 @@ final class SearchViewController: GraceLogBaseViewController<SearchViewReactor> 
             .map { SearchViewReactor.Action.didTapAddCommunityButton }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
+        // TODO: - 공동체 생성 이후 다시 돌아왔을때 이벤트 구현 필요
+        NotificationCenterManager.reloadCommunityList.addObserver()
+            .subscribe(with: self) { _, _ in
+                print("공동체 생성 성공")
+            }
+            .disposed(by: disposeBag)
+            
     }
     
     private func setupDataSource() {

--- a/GraceLog/Source/Util/Dependency/DependencyContainer.swift
+++ b/GraceLog/Source/Util/Dependency/DependencyContainer.swift
@@ -26,6 +26,7 @@ final class DependencyContainer {
             DiaryDetailsPresentationAssembly(),
             DiarySettingsPresentationAssembly(),
             CreateCommunityPresentationAssembly()
+            CommunityGroupPresentationAssembly()
         ])
         return injector
     }()

--- a/GraceLog/Source/Util/Dependency/DependencyContainer.swift
+++ b/GraceLog/Source/Util/Dependency/DependencyContainer.swift
@@ -25,7 +25,7 @@ final class DependencyContainer {
             AnnouncementPresentationAssembly(),
             DiaryDetailsPresentationAssembly(),
             DiarySettingsPresentationAssembly(),
-            CreateCommunityPresentationAssembly()
+            CreateCommunityPresentationAssembly(),
             CommunityGroupPresentationAssembly()
         ])
         return injector

--- a/GraceLog/Source/Util/Dependency/DependencyContainer.swift
+++ b/GraceLog/Source/Util/Dependency/DependencyContainer.swift
@@ -24,7 +24,8 @@ final class DependencyContainer {
             ProfileEditPresentationAssembly(),
             AnnouncementPresentationAssembly(),
             DiaryDetailsPresentationAssembly(),
-            DiarySettingsPresentationAssembly()
+            DiarySettingsPresentationAssembly(),
+            CreateCommunityPresentationAssembly()
         ])
         return injector
     }()

--- a/GraceLog/Source/Util/Dependency/DependencyInjector.swift
+++ b/GraceLog/Source/Util/Dependency/DependencyInjector.swift
@@ -17,6 +17,8 @@ public protocol DependencyResolvable {
     func resolve<T>(_ serviceType: T.Type) -> T
     func resolve<T, Arg1>(_ serviceType: T.Type, argument: Arg1) -> T
     func resolve<T, Arg1, Arg2>(_ serviceType: T.Type, arguments arg1: Arg1, _ arg2: Arg2) -> T
+    func resolve<T, Arg1, Arg2, Arg3>(_ serviceType: T.Type, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> T
+    func resolve<T, Arg1, Arg2, Arg3, Arg4>(_ serviceType: T.Type, arguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> T
 }
 
 public typealias Injector = DependencyAssemblable & DependencyResolvable

--- a/GraceLog/Source/Util/Extension/String+Extension.swift
+++ b/GraceLog/Source/Util/Extension/String+Extension.swift
@@ -39,4 +39,15 @@ extension String {
         
         return attributedString
     }
+    
+    func toDate() -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = TimeZone(identifier: "UTC")
+        if let date = dateFormatter.date(from: self) {
+            return date
+        } else {
+            return nil
+        }
+    }
 }

--- a/GraceLog/Source/Util/KeyChain/TokenManager.swift
+++ b/GraceLog/Source/Util/KeyChain/TokenManager.swift
@@ -41,3 +41,10 @@ final class TokenManager: KeychainService {
         return accessToken != nil
     }
 }
+
+extension TokenManager {
+    func clearTokens() {
+        keychainAccess.remove(Key.accessToken)
+        keychainAccess.remove(Key.refreshToken)
+    }
+}

--- a/GraceLog/Source/Util/Manager/DateFormatterFactory.swift
+++ b/GraceLog/Source/Util/Manager/DateFormatterFactory.swift
@@ -39,6 +39,17 @@ enum DateFormatterFactory {
         yearMonth.string(from: date)
     }
     
+    static var dateOnly: DateFormatter {
+        formatter.then {
+            $0.dateFormat = "yyyy-MM-dd"
+            $0.locale = Locale(identifier: "en_US_POSIX")
+        }
+    }
+    
+    static func toDateOnlyString(from date: Date) -> String {
+        dateOnly.string(from: date)
+    }
+    
     /// 년도, 월을 통해 해당 년도 월의 첫번째, 마지막 날짜를 반환
     // TODO: 다른 DateFormatterFactory 프로퍼티와 비교했을 때 이 클래스에 존재하기엔 모호 (리팩토링 필요)
     static func getMonthDateRange(year: Int, month: Int) -> (startDate: String, endDate: String) {

--- a/GraceLog/Source/Util/Manager/NotificationCenter/NotificationCenterManager.swift
+++ b/GraceLog/Source/Util/Manager/NotificationCenter/NotificationCenterManager.swift
@@ -12,6 +12,7 @@ enum NotificationCenterManager: NotificationCenterHandler {
     case reloadHomeMyDiaryList
     case reloadHomeCommunityDiaryList
     case reloadMyInfo
+    case reloadCommunityList
     
     var name: Notification.Name {
         switch self {
@@ -21,6 +22,8 @@ enum NotificationCenterManager: NotificationCenterHandler {
             return Notification.Name("reloadHomeCommunityDiaryList")
         case .reloadMyInfo:
             return Notification.Name("reloadMyInfo")
+        case .reloadCommunityList:
+            return Notification.Name("reloadCommunityList")
         }
     }
 }

--- a/GraceLog/Source/Util/Manager/NotificationCenter/NotificationCenterManager.swift
+++ b/GraceLog/Source/Util/Manager/NotificationCenter/NotificationCenterManager.swift
@@ -9,6 +9,7 @@ import Foundation
 import UIKit
 
 enum NotificationCenterManager: NotificationCenterHandler {
+    case authenticationDidFail
     case reloadHomeMyDiaryList
     case reloadHomeCommunityDiaryList
     case reloadMyInfo
@@ -16,6 +17,8 @@ enum NotificationCenterManager: NotificationCenterHandler {
     
     var name: Notification.Name {
         switch self {
+        case .authenticationDidFail:
+            return Notification.Name("authenticationDidFail")
         case .reloadHomeMyDiaryList:
             return Notification.Name("reloadHomeMyDiaryList")
         case .reloadHomeCommunityDiaryList:


### PR DESCRIPTION
## 작업 내용

- [ ] 일기 API 바뀐 스펙에 맞춘 수정
- [ ] 일기 상세 UI API 재연동
- [ ] 공동체 생성 API 연동
- [ ] 공동체 그룹 UI API 연동
- [ ] 토큰 리프래쉬 및 만료 시 중복 호출 방지 구현


<br/><br/><br/>
## 고민점 및 해결 방법 (Optional)
### 1. Interceptor 토큰 갱신 로직
문제 
- 한 화면에서 여러개의 API를 호출하는 경우 토큰이 만료된 경우 각 API 호출에서 모두 토큰 만료 에러 발생 및 3번의 토큰 갱신 요청 발생

해결(큐 기반 토큰 갱신을 통한 수정)
- 단일 토큰 갱신: 토큰 갱신이 진행 중일 때는 추가 갱신 요청 차단
- 요청 큐잉: 토큰 만료 에러를 받은 모든 요청 큐에 저장
- 일괄 처리: 토큰 갱신 완료 후 큐의 모든 요청 동시 처리



<br/><br/><br/>
## 논의 해봤으면 좋으점 (Optional)
- 일기 상세, 공동체 그룹 쪽이 서비스의 핵심이다 보니 UseCase에 로직에 대한 주석을 좀 달아뒀습니다! 이 부분에 대해서 논의가 필요해 보입니다.